### PR TITLE
Crash issue for offscreen iScroll

### DIFF
--- a/examples/carousel_hidden/index.html
+++ b/examples/carousel_hidden/index.html
@@ -15,7 +15,6 @@ var myScroll;
 function loaded() {
 	myScroll = new iScroll('wrapper', {
 		snap: true,
-		momentum: false,
 		hScrollbar: false,
 		onScrollEnd: function () {
 			document.querySelector('#indicator > li.active').className = '';
@@ -26,17 +25,16 @@ function loaded() {
 
 function show(){
   document.getElementById('wrapper').style.display = 'block';
-  loaded();
+  myScroll.refresh();
   return false;
 }
 
 function hide(){ 
-  myScroll.destroy();
-  myScroll = null;
   document.getElementById('wrapper').style.display = 'none';
   return false;
  }
 
+document.addEventListener('DOMContentLoaded', loaded, false);
 </script>
 
 <style type="text/css" media="all">

--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -877,6 +877,11 @@ iScroll.prototype = {
 
 		that.wrapperW = that.wrapper.clientWidth;
 		that.wrapperH = that.wrapper.clientHeight;
+    if(that.wrapperW == 0 || that.wrapperH == 0){
+      // Bail out - the wrapper has no size and that will screw up
+      // calculations. Best way to handle this?
+      return false;
+    }
 		that.scrollerW = m.round(that.scroller.offsetWidth * that.scale);
 		that.scrollerH = m.round((that.scroller.offsetHeight - that.offsetBottom - that.offsetTop) * that.scale);
 		that.maxScrollX = that.wrapperW - that.scrollerW;


### PR DESCRIPTION
This is a possible fix for issues #29 and #30. First commit adds test case that causes crash (toggle iscroll visibility on and then off again, then try resizing - browser crash).

Second commit is a possible fix. Error appears to be from relying on clientWidth/clientHeight being non-zero, so I made the refresh function return false immediately on those values. There's probably a better way to handle this... but it fixes the test case. 
