### PR TITLE
added option to disable click emulation on touch end

### DIFF
--- a/src/iscroll-lite.js
+++ b/src/iscroll-lite.js
@@ -64,6 +64,7 @@ var m = Math,
 			lockDirection: true,
 			useTransform: true,
 			useTransition: false,
+			emulateClick: true,
 
 			// Events
 			onRefresh: null,
@@ -280,7 +281,7 @@ iScroll.prototype = {
 		if (that.options.onBeforeScrollEnd) that.options.onBeforeScrollEnd.call(that, e);
 
 		if (!that.moved) {
-			if (hasTouch) {
+			if (hasTouch && that.options.emulateClick) {
 				// Find the last touched element
 				target = point.target;
 				while (target.nodeType != 1) target = target.parentNode;

--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -67,6 +67,7 @@ var m = Math,
 			useTransform: true,
 			useTransition: false,
 			checkDOMChanges: false,		// Experimental
+			emulateClick: true,
 
 			// Scrollbar
 			hScrollbar: true,
@@ -488,7 +489,7 @@ iScroll.prototype = {
 					that.doubleTapTimer = null;
 					if (that.options.onZoomStart) that.options.onZoomStart.call(that, e);
 					that.zoom(that.pointX, that.pointY, that.scale == 1 ? that.options.doubleTapZoom : 1);
-				} else {
+				} else if(that.options.emulateClick) {
 					that.doubleTapTimer = setTimeout(function () {
 						that.doubleTapTimer = null;
 


### PR DESCRIPTION
If onBeforeScrollStart set to null or  does not prevent default click emulation on touch end is not needed.

In my case preventDefault breaks history.pushState in mobile safari (i guess because of it's security policy that permits not user initiated address changes), so i disabled it and turned off window scrolling with document.ontouchmove = function(e){  e.preventDefault();}
