### PR TITLE
Added onZoomEnd call to balance the onZoomStart in the double-tap zoom case

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -489,6 +489,11 @@ iScroll.prototype = {
 					that.doubleTapTimer = null;
 					if (that.options.onZoomStart) that.options.onZoomStart.call(that, e);
 					that.zoom(that.pointX, that.pointY, that.scale == 1 ? that.options.doubleTapZoom : 1);
+					if (that.options.onZoomEnd) {
+						setTimeout(function() {
+							that.options.onZoomEnd.call(that, e);
+						}, 200); // 200 is default zoom duration
+					}
 				} else {
 					that.doubleTapTimer = setTimeout(function () {
 						that.doubleTapTimer = null;


### PR DESCRIPTION
Here's a patch for this omission which I noted previously
