### PR TITLE
Store iScroll object in DOM for easy reference

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -136,6 +136,8 @@ var m = Math,
 		if (that.options.checkDOMChanges) that.checkDOMTime = setInterval(function () {
 			that._checkDOMChanges();
 		}, 500);
+
+		that.wrapper.iscroll = that;
 	};
 
 // Prototype


### PR DESCRIPTION
I recently had a situation where I needed to turn off iScroll's `touchstart` detection for instances of iScroll that were in a low-z-index `iframe` (i.e. obscured by a nodes with a higher z-index) as it was messing with `input` elements elsewhere on the page. (See [this StackOverflow question](http://stackoverflow.com/questions/6876706/text-selection-bug-in-mobile-safari-with-iframes-and-ontouchstart) for more details.) Anyhow, since I wasn't keeping a reference to each iScroll element, I didn't have a way to temporarily turn off `touchstart` event detection as necessary. This patch adds an instance of iScroll into the DOM so it can be easily accessed later.

I'm honestly not sure if this is the best approach. I wouldn't usually be a fan of storing stuff in the DOM, but the simplicity of this solution won me over. I also don't know if this will cause memory leaks in some browsers. Any feedback or alternative solutions are very welcome!
