### PR TITLE
Fixed an incompatibility issue with date.js (www.datejs.com)

### DIFF
--- a/src/iscroll-lite.js
+++ b/src/iscroll-lite.js
@@ -201,7 +201,7 @@ iScroll.prototype = {
 		that.pointX = point.pageX;
 		that.pointY = point.pageY;
 
-		that.startTime = e.timeStamp || Date.now();
+		that.startTime = e.timeStamp || Date.now().getTime();
 
 		if (that.options.onScrollStart) that.options.onScrollStart.call(that, e);
 
@@ -217,7 +217,7 @@ iScroll.prototype = {
 			deltaY = point.pageY - that.pointY,
 			newX = that.x + deltaX,
 			newY = that.y + deltaY,
-			timestamp = e.timeStamp || Date.now();
+			timestamp = e.timeStamp || Date.now().getTime();
 
 		if (that.options.onBeforeScrollMove) that.options.onBeforeScrollMove.call(that, e);
 
@@ -274,7 +274,7 @@ iScroll.prototype = {
 			target, ev,
 			momentumX = { dist:0, time:0 },
 			momentumY = { dist:0, time:0 },
-			duration = (e.timeStamp || Date.now()) - that.startTime,
+			duration = (e.timeStamp || Date.now().getTime()) - that.startTime,
 			newPosX = that.x,
 			newPosY = that.y,
 			newDuration;
@@ -380,7 +380,7 @@ iScroll.prototype = {
 	_startAni: function () {
 		var that = this,
 			startX = that.x, startY = that.y,
-			startTime = Date.now(),
+			startTime = Date.now().getTime(),
 			step, easeOut,
 			animate;
 
@@ -408,7 +408,7 @@ iScroll.prototype = {
 		}
 		
 		animate = function () {
-			var now = Date.now(),
+			var now = Date.now().getTime(),
 				newX, newY;
 
 			if (now >= startTime + step.time) {

--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -362,7 +362,7 @@ iScroll.prototype = {
 		that.pointX = point.pageX;
 		that.pointY = point.pageY;
 
-		that.startTime = e.timeStamp || Date.now();
+		that.startTime = e.timeStamp || Date.now().getTime();
 
 		if (that.options.onScrollStart) that.options.onScrollStart.call(that, e);
 
@@ -379,7 +379,7 @@ iScroll.prototype = {
 			newX = that.x + deltaX,
 			newY = that.y + deltaY,
 			c1, c2, scale,
-			timestamp = e.timeStamp || Date.now();
+			timestamp = e.timeStamp || Date.now().getTime();
 
 		if (that.options.onBeforeScrollMove) that.options.onBeforeScrollMove.call(that, e);
 
@@ -460,7 +460,7 @@ iScroll.prototype = {
 			target, ev,
 			momentumX = { dist:0, time:0 },
 			momentumY = { dist:0, time:0 },
-			duration = (e.timeStamp || Date.now()) - that.startTime,
+			duration = (e.timeStamp || Date.now().getTime()) - that.startTime,
 			newPosX = that.x,
 			newPosY = that.y,
 			distX, distY,
@@ -690,7 +690,7 @@ iScroll.prototype = {
 	_startAni: function () {
 		var that = this,
 			startX = that.x, startY = that.y,
-			startTime = Date.now(),
+			startTime = Date.now().getTime(),
 			step, easeOut,
 			animate;
 
@@ -718,7 +718,7 @@ iScroll.prototype = {
 		}
 
 		animate = function () {
-			var now = Date.now(),
+			var now = Date.now().getTime(),
 				newX, newY;
 
 			if (now >= startTime + step.time) {


### PR DESCRIPTION
Date.now() should return a timestamp but date.js (www.datejs.com) returns a string instead, causing issues with the timestamp calculation in iScroll. This resulted in strange scrolling behavior.

I have replaced Date.now() references to Date.now().getTime() which always returns the original Date object's timestamp value.
