### PR TITLE
Option hasForm to allow events on form elements

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -90,9 +90,22 @@ var m = Math,
 			snap: false,
 			snapThreshold: 1,
 
+            // Support forms?
+            hasForm: false,             // Experimental
+
 			// Events
 			onRefresh: null,
-			onBeforeScrollStart: function (e) { e.preventDefault(); },
+			onBeforeScrollStart: function (e) {
+                if (that.options.hasForm) {
+                    var targetTag = e.target.tagName.toLowerCase();
+                    if (targetTag != 'input' && targetTag != 'select' && targetTag != 'textarea') {
+                        e.preventDefault();
+                    }
+
+                } else {
+                    e.preventDefault();
+                }
+            },
 			onScrollStart: null,
 			onBeforeScrollMove: null,
 			onScrollMove: null,
@@ -113,7 +126,7 @@ var m = Math,
 		}
 		// User defined options
 		for (i in options) that.options[i] = options[i];
-		
+console.log('hasForm: ' + that.options.hasForm);
 		// Set starting position
 		that.x = that.options.x;
 		that.y = that.options.y;


### PR DESCRIPTION
Hi cubiq,

Rather than people hacking the iscroll.js sources to get text input, textarea and select elements working again*, I suspect it might be easier (and less frustrating) for users if a configuration option was available until a better solution can be found.

This pull request includes a config option called "hasForm" that enables these elements.

Known issue: On Android 2.3.2 select elements appear to only work intermittently for me... still chasing it down.

Best regards
- https://groups.google.com/forum/#!searchin/iscroll/form/iscroll/BUygehLronU/X6Rq2UBQ24oJ
