### PR TITLE
Corrected the conditional to fix a leak.

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -867,7 +867,7 @@ iScroll.prototype = {
 		that._unbind(END_EV);
 		that._unbind(CANCEL_EV);
 		
-		if (that.options.hasTouch) {
+		if (!that.options.hasTouch) {
 			that._unbind('mouseout', that.wrapper);
 			that._unbind(WHEEL_EV);
 		}


### PR DESCRIPTION
Looks like a simple ! omission. I had noticed that onmouseout events were stacking up over time, and this seemed to do the job.

thank you for iScroll.
