### PR TITLE
IE 7/8 support added

### DIFF
--- a/examples/carousel/index.html
+++ b/examples/carousel/index.html
@@ -9,24 +9,6 @@
 
 <script type="text/javascript" src="../../src/iscroll.js"></script>
 
-<script type="text/javascript">
-var myScroll;
-
-function loaded() {
-	myScroll = new iScroll('wrapper', {
-		snap: true,
-		momentum: false,
-		hScrollbar: false,
-		onScrollEnd: function () {
-			document.querySelector('#indicator > li.active').className = '';
-			document.querySelector('#indicator > li:nth-child(' + (this.currPageX+1) + ')').className = 'active';
-		}
-	 });
-}
-
-document.addEventListener('DOMContentLoaded', loaded, false);
-</script>
-
 <style type="text/css" media="all">
 body,ul,li {
 	padding:10px;
@@ -166,5 +148,40 @@ body {
 	</ul>
 	<div id="next" onclick="myScroll.scrollToPage('next', 0);return false">next &rarr;</div>
 </div>
+
+<script type="text/javascript">
+
+
+var myScroll;
+
+
+function loaded() {
+
+	myScroll = new iScroll('wrapper', {
+		snap: true,
+		momentum: false,
+		hScrollbar: false,
+		onScrollEnd: function () {
+			document.querySelector('#indicator > li.active').className = '';
+			document.querySelector('#indicator > li:nth-child(' + (this.currPageX+1) + ')').className = 'active';
+		}
+	 });
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+
+</script>
+
 </body>
 </html>

--- a/examples/check-dom-changes/index.html
+++ b/examples/check-dom-changes/index.html
@@ -9,23 +9,6 @@
 
 <script type="text/javascript" src="../../src/iscroll.js"></script>
 
-<script type="text/javascript">
-
-var myScroll;
-function loaded() {
-	myScroll = new iScroll('wrapper', { checkDOMChanges: true });
-	
-	setInterval(function () {
-		if (myScroll.isReady())
-			document.getElementById('thelist').innerHTML += '<li>new row</li>';
-	}, 2000);
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-document.addEventListener('DOMContentLoaded', loaded, false);
-
-</script>
-
 <style type="text/css" media="all">
 body,ul,li {
 	padding:0;
@@ -167,6 +150,40 @@ body {
 	</div>
 </div>
 <div id="footer"></div>
+
+<script type="text/javascript">
+
+
+var myScroll;
+
+
+function loaded() {
+
+
+	myScroll = new iScroll('wrapper', { checkDOMChanges: true });
+	
+	setInterval(function () {
+		if (myScroll.isReady())
+			document.getElementById('thelist').innerHTML += '<li>new row</li>';
+	}, 2000);
+
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+
+</script>
 
 </body>
 </html>

--- a/examples/custom-scrollbar/index.html
+++ b/examples/custom-scrollbar/index.html
@@ -9,20 +9,7 @@
 
 <link rel="stylesheet" type="text/css" href="scrollbar.css">
 
-<script type="application/javascript" src="../../src/iscroll.js?v4"></script>
-
-<script type="text/javascript">
-
-var myScroll;
-function loaded() {
-	myScroll = new iScroll('wrapper', { scrollbarClass: 'myScrollbar' });
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-
-document.addEventListener('DOMContentLoaded', loaded, false);
-
-</script>
+<script type="text/javascript" src="../../src/iscroll.js?v4"></script>
 
 <style type="text/css" media="all">
 body,ul,li {
@@ -167,6 +154,33 @@ body {
 </div>
 
 <div id="footer"></div>
+
+<script type="text/javascript">
+
+
+var myScroll;
+
+
+function loaded() {
+
+	myScroll = new iScroll('wrapper', { scrollbarClass: 'myScrollbar' });
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+
+</script>
 
 </body>
 </html>

--- a/examples/form-fields/index.html
+++ b/examples/form-fields/index.html
@@ -9,27 +9,6 @@
 
 <script type="text/javascript" src="../../src/iscroll.js"></script>
 
-<script type="text/javascript">
-
-var myScroll;
-function loaded() {
-	myScroll = new iScroll('wrapper', {
-		useTransform: false,
-		onBeforeScrollStart: function (e) {
-			var target = e.target;
-			while (target.nodeType != 1) target = target.parentNode;
-
-			if (target.tagName != 'SELECT' && target.tagName != 'INPUT' && target.tagName != 'TEXTAREA')
-				e.preventDefault();
-		}
-	});
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-document.addEventListener('DOMContentLoaded', loaded, false);
-
-</script>
-
 <style type="text/css" media="all">
 body,ul,li {
 	padding:0;
@@ -171,6 +150,42 @@ body {
 	</div>
 </div>
 <div id="footer"></div>
+
+<script type="text/javascript">
+
+
+var myScroll;
+
+
+function loaded() {
+
+	myScroll = new iScroll('wrapper', {
+		useTransform: false,
+		onBeforeScrollStart: function (e) {
+			var target = e.target;
+			while (target.nodeType != 1) target = target.parentNode;
+
+			if (target.tagName != 'SELECT' && target.tagName != 'INPUT' && target.tagName != 'TEXTAREA')
+				e.preventDefault();
+		}
+	});
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+
+</script>
 
 </body>
 </html>

--- a/examples/horizontal-scroll/index.html
+++ b/examples/horizontal-scroll/index.html
@@ -7,20 +7,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
 <title>iScroll demo: horizontal scroll</title>
 
-<script type="application/javascript" src="../../src/iscroll.js"></script>
-
-<script type="text/javascript">
-
-var myScroll;
-function loaded() {
-	myScroll = new iScroll('wrapper');
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-
-document.addEventListener('DOMContentLoaded', loaded, false);
-
-</script>
+<script type="text/javascript" src="../../src/iscroll.js"></script>
 
 <style type="text/css" media="all">
 body,ul,li {
@@ -129,6 +116,32 @@ body {
 		</ul>
 	</div>
 </div>
+
+<script type="text/javascript">
+
+
+var myScroll;
+
+
+function loaded() {
+
+	myScroll = new iScroll('wrapper');
+
+}
+
+
+if (document.addEventListener) {
+	
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+</script>
 
 </body>
 </html>

--- a/examples/hover/index.html
+++ b/examples/hover/index.html
@@ -9,45 +9,6 @@
 
 <script type="text/javascript" src="../../src/iscroll.js"></script>
 
-<script type="text/javascript">
-
-var myScroll,
-	hoverClassRegEx = new RegExp('(^|\\s)iScrollHover(\\s|$)'),
-	removeClass = function () {
-		if (this.hoverTarget) {
-			clearTimeout(this.hoverTimeout);
-			this.hoverTarget.className = this.hoverTarget.className.replace(hoverClassRegEx, '');
-			this.target = null;
-		}
-	};
-
-function loaded() {
-	myScroll = new iScroll('wrapper', {
-		onBeforeScrollStart: function (e) {
-			var target = e.target;
-
-			clearTimeout(this.hoverTimeout);
-
-			while (target.nodeType != 1) target = target.parentNode;
-
-			this.hoverTimeout = setTimeout(function () {
-				if (!hoverClassRegEx.test(target.className)) target.className = target.className ? target.className + ' iScrollHover' : 'iScrollHover';
-			}, 80);
-
-			this.hoverTarget = target;
-			
-			e.preventDefault();
-		},
-		onScrollMove: removeClass,
-		onBeforeScrollEnd: removeClass
-	});
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-document.addEventListener('DOMContentLoaded', loaded, false);
-
-</script>
-
 <style type="text/css" media="all">
 .iScrollHover {
 	background:#444 !important;
@@ -194,6 +155,57 @@ body {
 	</div>
 </div>
 <div id="footer"></div>
+
+<script type="text/javascript">
+
+
+var myScroll,
+	hoverClassRegEx = new RegExp('(^|\\s)iScrollHover(\\s|$)'),
+	removeClass = function () {
+		if (this.hoverTarget) {
+			clearTimeout(this.hoverTimeout);
+			this.hoverTarget.className = this.hoverTarget.className.replace(hoverClassRegEx, '');
+			this.target = null;
+		}
+	};
+
+
+function loaded() {
+	myScroll = new iScroll('wrapper', {
+		onBeforeScrollStart: function (e) {
+			var target = e.target;
+
+			clearTimeout(this.hoverTimeout);
+
+			while (target.nodeType != 1) target = target.parentNode;
+
+			this.hoverTimeout = setTimeout(function () {
+				if (!hoverClassRegEx.test(target.className)) target.className = target.className ? target.className + ' iScrollHover' : 'iScrollHover';
+			}, 80);
+
+			this.hoverTarget = target;
+			
+			e.preventDefault();
+		},
+		onScrollMove: removeClass,
+		onBeforeScrollEnd: removeClass
+	});
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+
+</script>
 
 </body>
 </html>

--- a/examples/ipad/index.html
+++ b/examples/ipad/index.html
@@ -7,23 +7,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
 <title>iScroll demo: iPad</title>
 
-<script type="application/javascript" src="../../src/iscroll.js"></script>
-
-<script type="text/javascript">
-
-var scrollContent,
-	scrollNav;
-
-function loaded() {
-	scrollContent = new iScroll('contentWrapper');
-	scrollNav = new iScroll('navWrapper');
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-
-document.addEventListener('DOMContentLoaded', loaded, false);
-
-</script>
+<script type="text/javascript" src="../../src/iscroll.js"></script>
 
 <style type="text/css" media="all">
 html,body {
@@ -162,6 +146,34 @@ nav, article {
 		</article>
 	</div>
 </div>
+
+<script type="text/javascript">
+
+
+var scrollContent,
+	scrollNav;
+
+
+function loaded() {
+
+	scrollContent = new iScroll('contentWrapper');
+	scrollNav = new iScroll('navWrapper');
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+</script>
 
 </body>
 </html>

--- a/examples/lite/index.html
+++ b/examples/lite/index.html
@@ -7,20 +7,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
 <title>iScroll demo: lite edition</title>
 
-<script type="application/javascript" src="../../src/iscroll-lite.js?v4"></script>
-
-<script type="text/javascript">
-
-var myScroll;
-function loaded() {
-	myScroll = new iScroll('wrapper');
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-
-document.addEventListener('DOMContentLoaded', loaded, false);
-
-</script>
+<script type="text/javascript" src="../../src/iscroll-lite.js?v4"></script>
 
 <style type="text/css" media="all">
 body,ul,li {
@@ -156,6 +143,33 @@ body {
 </div>
 
 <div id="footer"></div>
+
+<script type="text/javascript">
+
+
+var myScroll;
+
+
+function loaded() {
+
+	myScroll = new iScroll('wrapper');
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', loaded, false);
+
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+
+</script>
 
 </body>
 </html>

--- a/examples/pull-to-refresh/index.html
+++ b/examples/pull-to-refresh/index.html
@@ -9,101 +9,6 @@
 
 <script type="text/javascript" src="../../src/iscroll.js"></script>
 
-<script type="text/javascript">
-
-var myScroll,
-	pullDownEl, pullDownOffset,
-	pullUpEl, pullUpOffset,
-	generatedCount = 0;
-
-function pullDownAction () {
-	setTimeout(function () {	// <-- Simulate network congestion, remove setTimeout from production!
-		var el, li, i;
-		el = document.getElementById('thelist');
-
-		for (i=0; i<3; i++) {
-			li = document.createElement('li');
-			li.innerText = 'Generated row ' + (++generatedCount);
-			el.insertBefore(li, el.childNodes[0]);
-		}
-		
-		myScroll.refresh();		// Remember to refresh when contents are loaded (ie: on ajax completion)
-	}, 1000);	// <-- Simulate network congestion, remove setTimeout from production!
-}
-
-function pullUpAction () {
-	setTimeout(function () {	// <-- Simulate network congestion, remove setTimeout from production!
-		var el, li, i;
-		el = document.getElementById('thelist');
-
-		for (i=0; i<3; i++) {
-			li = document.createElement('li');
-			li.innerText = 'Generated row ' + (++generatedCount);
-			el.appendChild(li, el.childNodes[0]);
-		}
-		
-		myScroll.refresh();		// Remember to refresh when contents are loaded (ie: on ajax completion)
-	}, 1000);	// <-- Simulate network congestion, remove setTimeout from production!
-}
-
-function loaded() {
-	pullDownEl = document.getElementById('pullDown');
-	pullDownOffset = pullDownEl.offsetHeight;
-	pullUpEl = document.getElementById('pullUp');	
-	pullUpOffset = pullUpEl.offsetHeight;
-	
-	myScroll = new iScroll('wrapper', {
-		useTransition: true,
-		topOffset: pullDownOffset,
-		onRefresh: function () {
-			if (pullDownEl.className.match('loading')) {
-				pullDownEl.className = '';
-				pullDownEl.querySelector('.pullDownLabel').innerHTML = 'Pull down to refresh...';
-			} else if (pullUpEl.className.match('loading')) {
-				pullUpEl.className = '';
-				pullUpEl.querySelector('.pullUpLabel').innerHTML = 'Pull up to load more...';
-			}
-		},
-		onScrollMove: function () {
-			if (this.y > 5 && !pullDownEl.className.match('flip')) {
-				pullDownEl.className = 'flip';
-				pullDownEl.querySelector('.pullDownLabel').innerHTML = 'Release to refresh...';
-				this.minScrollY = 0;
-			} else if (this.y < 5 && pullDownEl.className.match('flip')) {
-				pullDownEl.className = '';
-				pullDownEl.querySelector('.pullDownLabel').innerHTML = 'Pull down to refresh...';
-				this.minScrollY = -pullDownOffset;
-			} else if (this.y < (this.maxScrollY - 5) && !pullUpEl.className.match('flip')) {
-				pullUpEl.className = 'flip';
-				pullUpEl.querySelector('.pullUpLabel').innerHTML = 'Release to refresh...';
-				this.maxScrollY = this.maxScrollY;
-			} else if (this.y > (this.maxScrollY + 5) && pullUpEl.className.match('flip')) {
-				pullUpEl.className = '';
-				pullUpEl.querySelector('.pullUpLabel').innerHTML = 'Pull up to load more...';
-				this.maxScrollY = pullUpOffset;
-			}
-		},
-		onScrollEnd: function () {
-			if (pullDownEl.className.match('flip')) {
-				pullDownEl.className = 'loading';
-				pullDownEl.querySelector('.pullDownLabel').innerHTML = 'Loading...';				
-				pullDownAction();	// Execute custom function (ajax call?)
-			} else if (pullUpEl.className.match('flip')) {
-				pullUpEl.className = 'loading';
-				pullUpEl.querySelector('.pullUpLabel').innerHTML = 'Loading...';				
-				pullUpAction();	// Execute custom function (ajax call?)
-			}
-		}
-	});
-	
-	setTimeout(function () { document.getElementById('wrapper').style.left = '0'; }, 800);
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-
-document.addEventListener('DOMContentLoaded', function () { setTimeout(loaded, 200); }, false);
-</script>
-
 <style type="text/css" media="all">
 body,ul,li {
 	padding:0;
@@ -308,6 +213,115 @@ body {
 	</div>
 </div>
 <div id="footer"></div>
+
+<script type="text/javascript">
+
+
+var myScroll,
+	pullDownEl, pullDownOffset,
+	pullUpEl, pullUpOffset,
+	generatedCount = 0;
+
+
+function pullDownAction () {
+	setTimeout(function () {	// <-- Simulate network congestion, remove setTimeout from production!
+		var el, li, i;
+		el = document.getElementById('thelist');
+
+		for (i=0; i<3; i++) {
+			li = document.createElement('li');
+			li.innerText = 'Generated row ' + (++generatedCount);
+			el.insertBefore(li, el.childNodes[0]);
+		}
+		
+		myScroll.refresh();		// Remember to refresh when contents are loaded (ie: on ajax completion)
+	}, 1000);	// <-- Simulate network congestion, remove setTimeout from production!
+}
+
+
+function pullUpAction () {
+	setTimeout(function () {	// <-- Simulate network congestion, remove setTimeout from production!
+		var el, li, i;
+		el = document.getElementById('thelist');
+
+		for (i=0; i<3; i++) {
+			li = document.createElement('li');
+			li.innerText = 'Generated row ' + (++generatedCount);
+			el.appendChild(li, el.childNodes[0]);
+		}
+		
+		myScroll.refresh();		// Remember to refresh when contents are loaded (ie: on ajax completion)
+	}, 1000);	// <-- Simulate network congestion, remove setTimeout from production!
+}
+
+
+function loaded() {
+	pullDownEl = document.getElementById('pullDown');
+	pullDownOffset = pullDownEl.offsetHeight;
+	pullUpEl = document.getElementById('pullUp');	
+	pullUpOffset = pullUpEl.offsetHeight;
+	
+	myScroll = new iScroll('wrapper', {
+		useTransition: true,
+		topOffset: pullDownOffset,
+		onRefresh: function () {
+			if (pullDownEl.className.match('loading')) {
+				pullDownEl.className = '';
+				pullDownEl.querySelector('.pullDownLabel').innerHTML = 'Pull down to refresh...';
+			} else if (pullUpEl.className.match('loading')) {
+				pullUpEl.className = '';
+				pullUpEl.querySelector('.pullUpLabel').innerHTML = 'Pull up to load more...';
+			}
+		},
+		onScrollMove: function () {
+			if (this.y > 5 && !pullDownEl.className.match('flip')) {
+				pullDownEl.className = 'flip';
+				pullDownEl.querySelector('.pullDownLabel').innerHTML = 'Release to refresh...';
+				this.minScrollY = 0;
+			} else if (this.y < 5 && pullDownEl.className.match('flip')) {
+				pullDownEl.className = '';
+				pullDownEl.querySelector('.pullDownLabel').innerHTML = 'Pull down to refresh...';
+				this.minScrollY = -pullDownOffset;
+			} else if (this.y < (this.maxScrollY - 5) && !pullUpEl.className.match('flip')) {
+				pullUpEl.className = 'flip';
+				pullUpEl.querySelector('.pullUpLabel').innerHTML = 'Release to refresh...';
+				this.maxScrollY = this.maxScrollY;
+			} else if (this.y > (this.maxScrollY + 5) && pullUpEl.className.match('flip')) {
+				pullUpEl.className = '';
+				pullUpEl.querySelector('.pullUpLabel').innerHTML = 'Pull up to load more...';
+				this.maxScrollY = pullUpOffset;
+			}
+		},
+		onScrollEnd: function () {
+			if (pullDownEl.className.match('flip')) {
+				pullDownEl.className = 'loading';
+				pullDownEl.querySelector('.pullDownLabel').innerHTML = 'Loading...';				
+				pullDownAction();	// Execute custom function (ajax call?)
+			} else if (pullUpEl.className.match('flip')) {
+				pullUpEl.className = 'loading';
+				pullUpEl.querySelector('.pullUpLabel').innerHTML = 'Loading...';				
+				pullUpAction();	// Execute custom function (ajax call?)
+			}
+		}
+	});
+	
+	setTimeout(function () { document.getElementById('wrapper').style.left = '0'; }, 800);
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', function () { setTimeout(loaded, 200); }, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+
+</script>
 
 </body>
 </html>

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -9,45 +9,6 @@
 
 <script type="text/javascript" src="../../src/iscroll.js"></script>
 
-<script type="text/javascript">
-
-var myScroll;
-function loaded() {
-	myScroll = new iScroll('wrapper');
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-
-/* * * * * * * *
- *
- * Use this for high compatibility (iDevice + Android)
- *
- */
-document.addEventListener('DOMContentLoaded', function () { setTimeout(loaded, 200); }, false);
-/*
- * * * * * * * */
-
-
-/* * * * * * * *
- *
- * Use this for iDevice only
- *
- */
-//document.addEventListener('DOMContentLoaded', loaded, false);
-/*
- * * * * * * * */
-
-
-/* * * * * * * *
- *
- * Use this if nothing else works
- *
- */
-//window.addEventListener('load', setTimeout(function () { loaded(); }, 200), false);
-/*
- * * * * * * * */
-
-</script>
 
 <style type="text/css" media="all">
 body,ul,li {
@@ -190,6 +151,63 @@ body {
 	</div>
 </div>
 <div id="footer"></div>
+
+
+<script type="text/javascript">
+
+
+var myScroll;
+
+
+function loaded() {
+
+	myScroll = new iScroll('wrapper');
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+
+	/* * * * * * * *
+	 *
+	 * Use this for high compatibility (iDevice + Android)
+	 *
+	 */
+	document.addEventListener('DOMContentLoaded', function () { setTimeout(loaded, 200); }, false);
+	/*
+	 * * * * * * * */
+	
+	
+	/* * * * * * * *
+	 *
+	 * Use this for iDevice only
+	 *
+	 */
+	//document.addEventListener('DOMContentLoaded', loaded, false);
+	/*
+	 * * * * * * * */
+	
+	
+	/* * * * * * * *
+	 *
+	 * Use this if nothing else works
+	 *
+	 */
+	//window.addEventListener('load', setTimeout(function () { loaded(); }, 200), false);
+	/*
+	 * * * * * * * */
+
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+
+</script>	
+
 
 </body>
 </html>

--- a/examples/snap-to-element/index.html
+++ b/examples/snap-to-element/index.html
@@ -9,21 +9,6 @@
 
 <script type="text/javascript" src="../../src/iscroll.js"></script>
 
-<script type="text/javascript">
-var myScroll;
-
-function loaded() {
-	myScroll = new iScroll('wrapper', {
-		snap: 'li',
-		momentum: false,
-		hScrollbar: false,
-		vScrollbar: false
-	 });
-}
-
-document.addEventListener('DOMContentLoaded', loaded, false);
-</script>
-
 <style type="text/css" media="all">
 body,ul,li {
 	padding:0;
@@ -128,6 +113,36 @@ body {
 		</ul>
 	</div>
 </div>
+
+<script type="text/javascript">
+
+
+var myScroll;
+
+
+function loaded() {
+
+	myScroll = new iScroll('wrapper', {
+		snap: 'li',
+		momentum: false,
+		hScrollbar: false,
+		vScrollbar: false
+	 });
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+</script>
 
 </body>
 </html>

--- a/examples/use-transition/index.html
+++ b/examples/use-transition/index.html
@@ -9,19 +9,6 @@
 
 <script type="text/javascript" src="../../src/iscroll.js"></script>
 
-<script type="text/javascript">
-
-var scroll1, scroll2;
-function loaded() {
-	scroll1 = new iScroll('standard');
-	scroll2 = new iScroll('transition', { useTransition:true });
-}
-
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
-document.addEventListener('DOMContentLoaded', loaded, false);
-
-</script>
-
 <style type="text/css" media="all">
 ul,li {
 	padding:0;
@@ -181,6 +168,32 @@ body {
 	</div>
 </div>
 
+<script type="text/javascript">
+
+
+var scroll1, scroll2;
+
+
+function loaded() {
+
+	scroll1 = new iScroll('standard');
+	scroll2 = new iScroll('transition', { useTransition:true });
+
+}
+
+
+if (document.addEventListener) {
+
+	document.addEventListener('touchmove', function (e) { e.preventDefault(); }, false);
+	document.addEventListener('DOMContentLoaded', loaded, false);
+	
+} else {
+
+	document.body.onload = loaded;
+
+}
+
+</script>
 
 </body>
 </html>

--- a/src/iscroll-lite.js
+++ b/src/iscroll-lite.js
@@ -15,6 +15,7 @@ var m = Math,
     isIDevice = (/iphone|ipad/gi).test(navigator.appVersion),
     isPlaybook = (/playbook/gi).test(navigator.appVersion),
     isTouchPad = (/hp-tablet/gi).test(navigator.appVersion),
+    isOldIE = (document.all) && !document.getElementsByClassName, // IE < 9.
 
     has3d = 'WebKitCSSMatrix' in window && 'm11' in new WebKitCSSMatrix(),
     hasTouch = 'ontouchstart' in window && !isTouchPad,
@@ -44,6 +45,7 @@ var m = Math,
 	MOVE_EV = hasTouch ? 'touchmove' : 'mousemove',
 	END_EV = hasTouch ? 'touchend' : 'mouseup',
 	CANCEL_EV = hasTouch ? 'touchcancel' : 'mouseup',
+	MOUSEOUT_EV = document.attachEvent ? 'mouseleave' : 'mouseout',
 
 	// Helpers
 	trnOpen = 'translate' + (has3d ? '3d(' : '('),
@@ -74,7 +76,15 @@ var m = Math,
 
 			// Events
 			onRefresh: null,
-			onBeforeScrollStart: function (e) { e.preventDefault(); },
+			onBeforeScrollStart: function (e) { 
+
+				if (e.preventDefault) {
+					e.preventDefault();
+				} else {
+					e.returnValue = false;
+				}
+				 
+			},
 			onScrollStart: null,
 			onBeforeScrollMove: null,
 			onScrollMove: null,
@@ -107,6 +117,9 @@ var m = Math,
 		else that.scroller.style.cssText += ';position:absolute;top:' + that.y + 'px;left:' + that.x + 'px';
 
 		that.refresh();
+		
+		// Disable ondragstart (mainly for IE 8).
+		that.scroller.ondragstart = function () { return false; };
 
 		that._bind(RESIZE_EV, window);
 		that._bind(START_EV);
@@ -125,17 +138,19 @@ iScroll.prototype = {
 		var that = this;
 		switch(e.type) {
 			case START_EV:
-				if (!hasTouch && e.button !== 0) return;
+				if ((!hasTouch && e.button !== 0 && !isOldIE) || (isOldIE && e.button !== 1)) return;
 				that._start(e);
 				break;
 			case MOVE_EV: that._move(e); break;
 			case END_EV:
 			case CANCEL_EV: that._end(e); break;
 			case RESIZE_EV: that._resize(); break;
-			case 'mouseout': that._mouseout(e); break;
+			case MOUSEOUT_EV: that._mouseout(e); break;
 			case 'webkitTransitionEnd': that._transitionEnd(e); break;
 		}
 	},
+	
+	events : {},
 
 	_resize: function () {
 		this.refresh();
@@ -161,6 +176,8 @@ iScroll.prototype = {
 	_start: function (e) {
 		var that = this,
 			point = hasTouch ? e.touches[0] : e,
+			docBody = document.body,
+			docEl = document.documentElement,
 			matrix, x, y;
 
 		if (!that.enabled) return;
@@ -186,8 +203,9 @@ iScroll.prototype = {
 				x = matrix[4] * 1;
 				y = matrix[5] * 1;
 			} else {
-				x = getComputedStyle(that.scroller, null).left.replace(/[^0-9-]/g, '') * 1;
-				y = getComputedStyle(that.scroller, null).top.replace(/[^0-9-]/g, '') * 1;
+				// Use currentStyle if applicable (IE).
+				x = (that.scroller.currentStyle || getComputedStyle(that.scroller, null)).left.replace(/[^0-9-]/g, '') * 1;
+				y = (that.scroller.currentStyle || getComputedStyle(that.scroller, null)).top.replace(/[^0-9-]/g, '') * 1;
 			}
 			
 			if (x != that.x || y != that.y) {
@@ -200,10 +218,11 @@ iScroll.prototype = {
 
 		that.startX = that.x;
 		that.startY = that.y;
-		that.pointX = point.pageX;
-		that.pointY = point.pageY;
+		
+		that.pointX = (point.pageX || point.clientX + docBody.scrollLeft + docEl.scrollLeft);
+		that.pointY = (point.pageY || point.clientY + docBody.scrollTop + docEl.scrollTop);
 
-		that.startTime = e.timeStamp || Date.now();
+		that.startTime = e.timeStamp || new Date().getTime();
 
 		if (that.options.onScrollStart) that.options.onScrollStart.call(that, e);
 
@@ -215,16 +234,18 @@ iScroll.prototype = {
 	_move: function (e) {
 		var that = this,
 			point = hasTouch ? e.touches[0] : e,
-			deltaX = point.pageX - that.pointX,
-			deltaY = point.pageY - that.pointY,
+			docBody = document.body,
+			docEl = document.documentElement,
+			deltaX = (point.pageX || point.clientX + docBody.scrollLeft + docEl.scrollLeft) - that.pointX,
+			deltaY = (point.pageY || point.clientY + docBody.scrollTop + docEl.scrollTop) - that.pointY,
 			newX = that.x + deltaX,
 			newY = that.y + deltaY,
-			timestamp = e.timeStamp || Date.now();
+			timestamp = e.timeStamp || new Date().getTime();
 
 		if (that.options.onBeforeScrollMove) that.options.onBeforeScrollMove.call(that, e);
 
-		that.pointX = point.pageX;
-		that.pointY = point.pageY;
+		that.pointX = (point.pageX || point.clientX + docBody.scrollLeft + docEl.scrollLeft);
+		that.pointY = (point.pageY || point.clientY + docBody.scrollTop + docEl.scrollTop);
 
 		// Slow down if outside of the boundaries
 		if (newX > 0 || newX < that.maxScrollX) {
@@ -276,7 +297,7 @@ iScroll.prototype = {
 			target, ev,
 			momentumX = { dist:0, time:0 },
 			momentumY = { dist:0, time:0 },
-			duration = (e.timeStamp || Date.now()) - that.startTime,
+			duration = (e.timeStamp || new Date().getTime()) - that.startTime,
 			newPosX = that.x,
 			newPosY = that.y,
 			newDuration;
@@ -382,7 +403,7 @@ iScroll.prototype = {
 	_startAni: function () {
 		var that = this,
 			startX = that.x, startY = that.y,
-			startTime = Date.now(),
+			startTime = /* Date.now() */ new Date().getTime(),
 			step, easeOut,
 			animate;
 
@@ -410,7 +431,7 @@ iScroll.prototype = {
 		}
 		
 		animate = function () {
-			var now = Date.now(),
+			var now = new Date().getTime(),
 				newX, newY;
 
 			if (now >= startTime + step.time) {
@@ -474,11 +495,40 @@ iScroll.prototype = {
 	},
 
 	_bind: function (type, el, bubble) {
-		(el || this.scroller).addEventListener(type, this, !!bubble);
+
+		var fn = this;
+
+		if (document.addEventListener) {
+
+			(el || this.scroller).addEventListener(type, this, !!bubble);
+
+		} else {
+		
+			// Store function so we can detachEvent later.
+			this.events[type] = function(e) {
+				fn.handleEvent.call(fn, e);
+			};
+		
+			(el || this.scroller).attachEvent('on' + type, this.events[type]);
+
+		}
+
 	},
 
 	_unbind: function (type, el, bubble) {
-		(el || this.scroller).removeEventListener(type, this, !!bubble);
+		
+		if (document.removeEventListener) {
+
+			(el || this.scroller).removeEventListener(type, this, !!bubble);
+
+		} else {
+
+			if (this.events[type]) {
+				(el || this.scroller).detachEvent('on' + type, this.events[type]);				
+			}
+
+		}
+		
 	},
 
 

--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -14,6 +14,7 @@ var m = Math,
     isIDevice = (/iphone|ipad/gi).test(navigator.appVersion),
     isPlaybook = (/playbook/gi).test(navigator.appVersion),
     isTouchPad = (/hp-tablet/gi).test(navigator.appVersion),
+    isOldIE = (document.all) && !document.getElementsByClassName, // IE < 9.
 
     has3d = 'WebKitCSSMatrix' in window && 'm11' in new WebKitCSSMatrix(),
     hasTouch = 'ontouchstart' in window && !isTouchPad,
@@ -44,6 +45,7 @@ var m = Math,
 	END_EV = hasTouch ? 'touchend' : 'mouseup',
 	CANCEL_EV = hasTouch ? 'touchcancel' : 'mouseup',
 	WHEEL_EV = vendor == 'Moz' ? 'DOMMouseScroll' : 'mousewheel',
+	MOUSEOUT_EV = document.attachEvent ? 'mouseleave' : 'mouseout',
 
 	// Helpers
 	trnOpen = 'translate' + (has3d ? '3d(' : '('),
@@ -95,7 +97,15 @@ var m = Math,
 
 			// Events
 			onRefresh: null,
-			onBeforeScrollStart: function (e) { e.preventDefault(); },
+			onBeforeScrollStart: function (e) { 
+
+				if (e.preventDefault) {
+					e.preventDefault();
+				} else {
+					e.returnValue = false;
+				}
+				 
+			},
 			onScrollStart: null,
 			onBeforeScrollMove: null,
 			onScrollMove: null,
@@ -142,6 +152,9 @@ var m = Math,
 		if (that.options.useTransition) that.options.fixedScrollbar = true;
 
 		that.refresh();
+		
+		// Disable ondragstart (mainly for IE 8).
+		that.scroller.ondragstart = function () { return false; };
 
 		that._bind(RESIZE_EV, window);
 		that._bind(START_EV);
@@ -172,7 +185,7 @@ iScroll.prototype = {
 		var that = this;
 		switch(e.type) {
 			case START_EV:
-				if (!hasTouch && e.button !== 0) return;
+				if ((!hasTouch && e.button !== 0 && !isOldIE) || (isOldIE && e.button !== 1)) return;
 				that._start(e);
 				break;
 			case MOVE_EV: that._move(e); break;
@@ -180,10 +193,12 @@ iScroll.prototype = {
 			case CANCEL_EV: that._end(e); break;
 			case RESIZE_EV: that._resize(); break;
 			case WHEEL_EV: that._wheel(e); break;
-			case 'mouseout': that._mouseout(e); break;
+			case MOUSEOUT_EV: that._mouseout(e); break;
 			case 'webkitTransitionEnd': that._transitionEnd(e); break;
 		}
 	},
+	
+	events : {},
 	
 	_checkDOMChanges: function () {
 		if (this.moved || this.zoomed || this.animating ||
@@ -310,6 +325,8 @@ iScroll.prototype = {
 	_start: function (e) {
 		var that = this,
 			point = hasTouch ? e.touches[0] : e,
+			docBody = document.body,
+			docEl = document.documentElement,
 			matrix, x, y,
 			c1, c2;
 
@@ -348,8 +365,9 @@ iScroll.prototype = {
 				x = matrix[4] * 1;
 				y = matrix[5] * 1;
 			} else {
-				x = getComputedStyle(that.scroller, null).left.replace(/[^0-9-]/g, '') * 1;
-				y = getComputedStyle(that.scroller, null).top.replace(/[^0-9-]/g, '') * 1;
+				// Use currentStyle if applicable (IE).
+				x = (that.scroller.currentStyle || getComputedStyle(that.scroller, null)).left.replace(/[^0-9-]/g, '') * 1;
+				y = (that.scroller.currentStyle || getComputedStyle(that.scroller, null)).top.replace(/[^0-9-]/g, '') * 1;
 			}
 			
 			if (x != that.x || y != that.y) {
@@ -365,10 +383,11 @@ iScroll.prototype = {
 
 		that.startX = that.x;
 		that.startY = that.y;
-		that.pointX = point.pageX;
-		that.pointY = point.pageY;
+		
+		that.pointX = (point.pageX || point.clientX + docBody.scrollLeft + docEl.scrollLeft);
+		that.pointY = (point.pageY || point.clientY + docBody.scrollTop + docEl.scrollTop);
 
-		that.startTime = e.timeStamp || Date.now();
+		that.startTime = e.timeStamp || new Date().getTime();
 
 		if (that.options.onScrollStart) that.options.onScrollStart.call(that, e);
 
@@ -380,12 +399,14 @@ iScroll.prototype = {
 	_move: function (e) {
 		var that = this,
 			point = hasTouch ? e.touches[0] : e,
-			deltaX = point.pageX - that.pointX,
-			deltaY = point.pageY - that.pointY,
+			docBody = document.body,
+			docEl = document.documentElement,
+			deltaX = (point.pageX || point.clientX + docBody.scrollLeft + docEl.scrollLeft) - that.pointX,
+			deltaY = (point.pageY || point.clientY + docBody.scrollTop + docEl.scrollTop) - that.pointY,
 			newX = that.x + deltaX,
 			newY = that.y + deltaY,
 			c1, c2, scale,
-			timestamp = e.timeStamp || Date.now();
+			timestamp = e.timeStamp || new Date().getTime();
 
 		if (that.options.onBeforeScrollMove) that.options.onBeforeScrollMove.call(that, e);
 
@@ -413,8 +434,8 @@ iScroll.prototype = {
 			return;
 		}
 
-		that.pointX = point.pageX;
-		that.pointY = point.pageY;
+		that.pointX = (point.pageX || point.clientX + docBody.scrollLeft + docEl.scrollLeft);
+		that.pointY = (point.pageY || point.clientY + docBody.scrollTop + docEl.scrollTop);
 
 		// Slow down if outside of the boundaries
 		if (newX > 0 || newX < that.maxScrollX) {
@@ -466,7 +487,7 @@ iScroll.prototype = {
 			target, ev,
 			momentumX = { dist:0, time:0 },
 			momentumY = { dist:0, time:0 },
-			duration = (e.timeStamp || Date.now()) - that.startTime,
+			duration = (e.timeStamp || new Date().getTime()) - that.startTime,
 			newPosX = that.x,
 			newPosY = that.y,
 			distX, distY,
@@ -696,7 +717,7 @@ iScroll.prototype = {
 	_startAni: function () {
 		var that = this,
 			startX = that.x, startY = that.y,
-			startTime = Date.now(),
+			startTime = new Date().getTime(),
 			step, easeOut,
 			animate;
 
@@ -724,7 +745,7 @@ iScroll.prototype = {
 		}
 
 		animate = function () {
-			var now = Date.now(),
+			var now = new Date().getTime(),
 				newX, newY;
 
 			if (now >= startTime + step.time) {
@@ -836,11 +857,40 @@ iScroll.prototype = {
 	},
 
 	_bind: function (type, el, bubble) {
-		(el || this.scroller).addEventListener(type, this, !!bubble);
+
+		var fn = this;
+
+		if (document.addEventListener) {
+
+			(el || this.scroller).addEventListener(type, this, !!bubble);
+
+		} else {
+		
+			// Store function so we can detachEvent later.
+			this.events[type] = function(e) {
+				fn.handleEvent.call(fn, e);
+			};
+		
+			(el || this.scroller).attachEvent('on' + type, this.events[type]);
+
+		}
+
 	},
 
 	_unbind: function (type, el, bubble) {
-		(el || this.scroller).removeEventListener(type, this, !!bubble);
+		
+		if (document.removeEventListener) {
+
+			(el || this.scroller).removeEventListener(type, this, !!bubble);
+
+		} else {
+
+			if (this.events[type]) {
+				(el || this.scroller).detachEvent('on' + type, this.events[type]);				
+			}
+
+		}
+		
 	},
 
 


### PR DESCRIPTION
No major changes - just a few tweaks:
- new Date().getTime() instead of Date.now()
- attachEvent used instead of addEventListener
- Variable for events added so IE can bind/unbind events rather than the object itself
- ondragstart returns false so scrolling with internal links works

It doesn't offer the **exact** same experience as modern browsers (e.g the scrollbar doesn't appear) but it _is_ usable and no longer throws errors.

I've updated the examples as best I can but haven't had chance to update those using modern JavaScript methods (e.g pull-to-refresh uses querySelector() in the callback).
