### PR TITLE
Fix threshold when scrolling is limited to one direction

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -122,6 +122,7 @@ var m = Math,
 		that.options.vScrollbar = that.options.vScroll && that.options.vScrollbar;
 		that.options.zoom = that.options.useTransform && that.options.zoom;
 		that.options.useTransition = hasTransitionEnd && that.options.useTransition;
+		that.options.lockDirection = that.options.hScroll && that.options.vScroll && that.options.lockDirection;
 
 		// Helpers FIX ANDROID BUG!
 		// translate3d and scale doesn't work together! 


### PR DESCRIPTION
Horizontal threshold will start scrolling even if it is locked to just scroll vertically.

You can't then recognize a swipe right to delete gesture on a vertical only list.

Also, I use scroll starting to cancel my long tap timer.
