### PR TITLE
Fixed a bug that tapping to stop scroll doesn't fire onScrollEnd event.

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -598,10 +598,8 @@ iScroll.prototype = {
 			resetY = that.y >= that.minScrollY || that.maxScrollY > 0 ? that.minScrollY : that.y < that.maxScrollY ? that.maxScrollY : that.y;
 
 		if (resetX == that.x && resetY == that.y) {
-			if (that.moved) {
-				that.moved = false;
-				if (that.options.onScrollEnd) that.options.onScrollEnd.call(that);		// Execute custom code on scroll end
-			}
+			that.moved = false;
+			if (that.options.onScrollEnd) that.options.onScrollEnd.call(that);		// Execute custom code on scroll end
 
 			if (that.hScrollbar && that.options.hideScrollbar) {
 				if (vendor == 'webkit') that.hScrollbarWrapper.style[vendor + 'TransitionDelay'] = '300ms';


### PR DESCRIPTION
Fixed a bug that tapping to stop scroll doesn't fire onScrollEnd event. (Issue #130)
