### PR TITLE
Fix scrollbar position with topOffset > 0

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -244,7 +244,7 @@ iScroll.prototype = {
 			that.vScrollbarIndicatorSize = m.max(mround(that.vScrollbarSize * that.vScrollbarSize / that.scrollerH), 8);
 			that.vScrollbarIndicator.style.height = that.vScrollbarIndicatorSize + 'px';
 			that.vScrollbarMaxScroll = that.vScrollbarSize - that.vScrollbarIndicatorSize;
-			that.vScrollbarProp = that.vScrollbarMaxScroll / (that.maxScrollY - that.options.topOffset);
+			that.vScrollbarProp = that.vScrollbarMaxScroll / (that.maxScrollY + that.options.topOffset);
 		}
 
 		// Reset position


### PR DESCRIPTION
When the topOffset option is non-zero, the scrollbar wouldn't go all the way to the top of the track. This annoyed me, so I tweaked it.
