### PR TITLE
Proper vendor prefix for IE

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -7,6 +7,7 @@ var m = Math,
 	mround = function (r) { return r >> 0; },
 	vendor = (/webkit/i).test(navigator.appVersion) ? 'webkit' :
 		(/firefox/i).test(navigator.userAgent) ? 'Moz' :
+		(/trident/i).test(navigator.userAgent) ? 'ms' :
 		'opera' in window ? 'O' : '',
 
     // Browser capabilities


### PR DESCRIPTION
iScroll's transforms work fine with IE, but you have to use IE's prefix
