### PR TITLE
Fixed wheel handling for IE

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -627,10 +627,12 @@ iScroll.prototype = {
 		if ('wheelDeltaX' in e) {
 			wheelDeltaX = e.wheelDeltaX / 12;
 			wheelDeltaY = e.wheelDeltaY / 12;
+		} else if('wheelDelta' in e) {
+			wheelDeltaX = wheelDeltaY = e.wheelDelta / 12;
 		} else if ('detail' in e) {
 			wheelDeltaX = wheelDeltaY = -e.detail * 3;
 		} else {
-			wheelDeltaX = wheelDeltaY = -e.wheelDelta;
+			return;
 		}
 		
 		if (that.options.wheelAction == 'zoom') {


### PR DESCRIPTION
We had the wheel math a little wrong for IE; this fixes it, while keeping the other browsers working as well.
