### PR TITLE
No longer using event.timeStamp; was giving bogus values in IE

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -369,7 +369,7 @@ iScroll.prototype = {
 		that.pointX = point.pageX;
 		that.pointY = point.pageY;
 
-		that.startTime = e.timeStamp || Date.now();
+		that.startTime = Date.now();
 
 		if (that.options.onScrollStart) that.options.onScrollStart.call(that, e);
 
@@ -386,7 +386,7 @@ iScroll.prototype = {
 			newX = that.x + deltaX,
 			newY = that.y + deltaY,
 			c1, c2, scale,
-			timestamp = e.timeStamp || Date.now();
+			timestamp = Date.now();
 
 		if (that.options.onBeforeScrollMove) that.options.onBeforeScrollMove.call(that, e);
 
@@ -467,7 +467,7 @@ iScroll.prototype = {
 			target, ev,
 			momentumX = { dist:0, time:0 },
 			momentumY = { dist:0, time:0 },
-			duration = (e.timeStamp || Date.now()) - that.startTime,
+			duration = Date.now() - that.startTime,
 			newPosX = that.x,
 			newPosY = that.y,
 			distX, distY,


### PR DESCRIPTION
this works fine without e.timeStamp, which breaks anyway on IE
