### PR TITLE
First move event can be dropped, leading to perception of poor performance on Android devices.

### DIFF
--- a/src/iscroll-lite.js
+++ b/src/iscroll-lite.js
@@ -235,11 +235,13 @@ iScroll.prototype = {
 			newY = that.options.bounce ? that.y + (deltaY / 2) : newY >= 0 || that.maxScrollY >= 0 ? 0 : that.maxScrollY;
 		}
 
+		that.distX += deltaX;
+		that.distY += deltaY;
+		that.absDistX = m.abs(that.distX);
+		that.absDistY = m.abs(that.distY);
+
 		if (that.absDistX < 6 && that.absDistY < 6) {
-			that.distX += deltaX;
-			that.distY += deltaY;
-			that.absDistX = m.abs(that.distX);
-			that.absDistY = m.abs(that.distY);
+			return;
 		}
 
 		// Lock direction

--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -425,11 +425,13 @@ iScroll.prototype = {
 			newY = that.options.bounce ? that.y + (deltaY / 2) : newY >= that.minScrollY || that.maxScrollY >= 0 ? that.minScrollY : that.maxScrollY;
 		}
 
+		that.distX += deltaX;
+		that.distY += deltaY;
+		that.absDistX = m.abs(that.distX);
+		that.absDistY = m.abs(that.distY);
+
 		if (that.absDistX < 6 && that.absDistY < 6) {
-			that.distX += deltaX;
-			that.distY += deltaY;
-			that.absDistX = m.abs(that.distX);
-			that.absDistY = m.abs(that.distY);
+			return;
 		}
 
 		// Lock direction


### PR DESCRIPTION
Tested with an HTC desire and Samsung Galaxy II, iscroll performance seems jerky and some quick swipes appear to stutter or get ignored.  However, I don't think it's a real performance problem, per se, but rather that the first move event can end up getting dropped on the floor without performing any scrolling.  

Watching the sequence of events for a scroll, it looks like a touchstart/touchend with only a single touchmove in between will not cause any scrolling, and contribute to a poor perceived performance on Android:

```
    if (that.absDistX < 6 && that.absDistY < 6) {
        that.distX += deltaX;
        that.distY += deltaY;
        that.absDistX = m.abs(that.distX);
        that.absDistY = m.abs(that.distY);

        return; // returning here means we miss the first move event
    }
```

Getting rid of the return statement here (line 436) and allowing the first event to initiate a scroll leads to a much improved user experience.  Incidentally, when I say "quick" swipes can provoke this problem, it's not unrealistically fast interaction, it's a fast but natural motion.

As for why this affects Android and not iOS or other devices, I would speculate that the resolution of touch events is simply higher on iOS such that the described scenario does not occur frequently.
