### PR TITLE
Fix handling clicks on input elements

### DIFF
--- a/src/iscroll-lite.js
+++ b/src/iscroll-lite.js
@@ -303,9 +303,9 @@ iScroll.prototype = {
 					ev._fake = true;
 					target.dispatchEvent(ev);
 				}
-                else {
-                    target.focus();
-                }
+				else {
+					target.focus();
+				}
 			}
 
 			that._resetPos(200);

--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -532,9 +532,9 @@ iScroll.prototype = {
 							ev._fake = true;
 							target.dispatchEvent(ev);
 						}
-                        else {
-                            target.focus();
-                        }
+						else {
+							target.focus();
+						}
 					}, that.options.zoom ? 250 : 0);
 				}
 			}


### PR DESCRIPTION
Before, iScroll prevented selecting input elements. 

With this fix, input elements now gain focus when clicking on them without having moved the content (analogous to the click event on e. g. links). 
