### PR TITLE
onPageChange event

### DIFF
--- a/examples/carousel/index.html
+++ b/examples/carousel/index.html
@@ -17,9 +17,9 @@ function loaded() {
 		snap: true,
 		momentum: false,
 		hScrollbar: false,
-		onScrollEnd: function () {
+		onPageChange: function (pageX, pageY) {
 			document.querySelector('#indicator > li.active').className = '';
-			document.querySelector('#indicator > li:nth-child(' + (this.currPageX+1) + ')').className = 'active';
+			document.querySelector('#indicator > li:nth-child(' + (pageX+1) + ')').className = 'active';
 		}
 	 });
 }

--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -97,6 +97,7 @@ var m = Math,
 
 			// Events
 			onRefresh: null,
+			onPageChange: null,
 			onBeforeScrollStart: function (e) { e.preventDefault(); },
 			onScrollStart: null,
 			onBeforeScrollMove: null,
@@ -972,6 +973,8 @@ iScroll.prototype = {
 		}
 
 		that._startAni();
+
+		if (that.options.onPageChange) that.options.onPageChange.call(that, that.currPageX, that.currPageY);
 	},
 
 	scrollToElement: function (el, time) {


### PR DESCRIPTION
I found it convenient to have an onPageChange event that reports pageX and pageY values right when they're known/set, so you don't have to wait all the way for an onScrollEnd event.

Updated the carousel example to show this in action -- the page dots are now much snappier in updating.
