### PR TITLE
Refactor to isolate calls to innerWidth/Height and clientWidth/Height

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -201,26 +201,12 @@ iScroll.prototype = {
 	// visual artifacts.
 	
 	// client = box + padding = inner
-	_clientWidth: function(ele) {
-		return ele.clientWidth;
-		//return $(ele).actual("innerWidth");
-	},
-	
-	_clientHeight: function(ele) {
-		return ele.clientHeight;
-		//return $(ele).actual("innerHeight");
-	},
+	_clientWidth:  function(ele) { return ele.clientWidth; },
+	_clientHeight: function(ele) { return ele.clientHeight; },
 	
 	// offset = box + padding + border = outer
-	_offsetWidth: function(ele) {
-		return ele.offsetWidth;
-		//return $(ele).actual("outerWidth");
-	},
-	
-	_offsetHeight: function(ele) {
-		return ele.offsetHeight;
-		//return $(ele).actual("outerHeight");
-	},
+	_offsetWidth:  function(ele) { return ele.offsetWidth; },
+	_offsetHeight: function(ele) { return ele.offsetHeight; },
 	
 	_checkDOMChanges: function () {
 		if (this.moved || this.zoomed || this.animating ||


### PR DESCRIPTION
Refactored to isolate calls to innerWidth/Height and clientWidth/Height
clientWidth/Height in overridable functions. This permits override for
platforms like jQuery Mobile that hide page content prior to a page
transition. DOM dimension functions can't get the dimensions of hidden
content. Solutions like the jquery.actual plugin for jQuery can. So, by
overriding it's possible to construct an iScroller before the page is
shown, and avoid unwanted visual artifacts.
