### PR TITLE
Fixed missing semis in return statements, & one global "i" in for loop

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -111,7 +111,7 @@ var m = Math,
 		};
 
 		// User defined options
-		for (var i in options) that.options[i] = options[i];
+		for (i in options) that.options[i] = options[i];
 		
 		// Set starting position
 		that.x = that.options.x;


### PR DESCRIPTION
Fixed missing semicolons in return statements. Also, fixed one case of global "i" in a for loop.
