### PR TITLE
onScrollEnd not firing if tapping to stop an ongoing momentum

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -322,6 +322,10 @@ iScroll.prototype = {
 		if (that.options.useTransition || that.options.zoom) that._transitionTime(0);
 
 		that.moved = false;
+		if (that.animating)
+                {
+                    that.wasAnimating = true;
+                }
 		that.animating = false;
 		that.zoomed = false;
 		that.distX = 0;
@@ -599,8 +603,9 @@ iScroll.prototype = {
 			resetY = that.y >= that.minScrollY || that.maxScrollY > 0 ? that.minScrollY : that.y < that.maxScrollY ? that.maxScrollY : that.y;
 
 		if (resetX == that.x && resetY == that.y) {
-			if (that.moved) {
+			if (that.moved || that.wasAnimating) {
 				that.moved = false;
+				that.wasAnimating = false;
 				if (that.options.onScrollEnd) that.options.onScrollEnd.call(that);		// Execute custom code on scroll end
 			}
 
@@ -716,6 +721,7 @@ iScroll.prototype = {
 		if (step.x == startX && step.y == startY) step.time = 0;
 
 		that.animating = true;
+		that.wasAnimating = false;
 		that.moved = true;
 		
 		if (that.options.useTransition) {


### PR DESCRIPTION
Scrolling a long list and letting the momentum run its course will fire onScrollEnd as expected. 

If you however tap the screen to stop the scrolling prematurely, onScrollEnd will not be fired.

The reason for this is that _start is fired again, resetting this.moved which makes _resetPos think that no movement took place. To counter this I've introduced a new variable called wasAnimating, using which _resetPos can accurately can fire onScrollEnd.

This is my first attempt at an update to this project so a harsh code review is appreciated.
