### PR TITLE
Added bottomOffset option. Facilitates pull-up-to-refresh with proper bounce.

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -74,6 +74,7 @@ var m = Math,
 			useTransform: true,
 			useTransition: false,
 			topOffset: 0,
+			bottomOffset: 0,
 			checkDOMChanges: false,		// Experimental
 
 			// Scrollbar
@@ -899,7 +900,7 @@ iScroll.prototype = {
 		that.scrollerW = mround(that.scroller.offsetWidth * that.scale);
 		that.scrollerH = mround((that.scroller.offsetHeight + that.minScrollY) * that.scale);
 		that.maxScrollX = that.wrapperW - that.scrollerW;
-		that.maxScrollY = that.wrapperH - that.scrollerH + that.minScrollY;
+		that.maxScrollY = that.wrapperH - that.scrollerH + that.minScrollY + (that.options.bottomOffset || 0);		
 		that.dirX = 0;
 		that.dirY = 0;
 


### PR DESCRIPTION
I added a bottomOffset option which has complementary functionally to topOffset. So, you can have content "below the fold" that you can drag into, but the scroller will bounce back to hide that content.

This is needed for a proper implementation of "pull up to refresh" to match "pull down to refresh" appearance.

You can hack this in an onRefresh() callback, but this is a cleaner and clearer way.
