### PR TITLE
Fixed issue that prevented native page scrolling on touch devices when swiping over an iscroll element

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -97,7 +97,9 @@ var m = Math,
 
 			// Events
 			onRefresh: null,
-			onBeforeScrollStart: function (e) { e.preventDefault(); },
+			onBeforeScrollStart: function (e) {
+				if(!hasTouch) e.preventDefault();
+			},
 			onScrollStart: null,
 			onBeforeScrollMove: null,
 			onScrollMove: null,
@@ -393,6 +395,7 @@ iScroll.prototype = {
 
 		// Zoom
 		if (that.options.zoom && hasTouch && e.touches.length > 1) {
+			e.preventDefault();
 			c1 = m.abs(e.touches[0].pageX - e.touches[1].pageX);
 			c2 = m.abs(e.touches[0].pageY - e.touches[1].pageY);
 			that.touchesDist = m.sqrt(c1*c1+c2*c2);
@@ -446,8 +449,16 @@ iScroll.prototype = {
 			}
 		}
 
+		var oldX = that.x;
+		var oldY = that.y;
+
 		that.moved = true;
 		that._pos(newX, newY);
+
+		if(hasTouch && (that.x != oldX || that.y != oldY)) {
+			e.preventDefault();
+		}
+
 		that.dirX = deltaX > 0 ? -1 : deltaX < 0 ? 1 : 0;
 		that.dirY = deltaY > 0 ? -1 : deltaY < 0 ? 1 : 0;
 


### PR DESCRIPTION
Hi,
Great library you have here. Thought I might contribute a fix/feature ...

This use case typically occurs when you have a horizontally iscroll'd element, but you want to have native vertical touch scrolling of the page. Previously iscroll would capture the event and preventDefault, thus preventing the native action to occur.

Here's the email thread regarding this issue: https://groups.google.com/d/topic/iscroll/qusOnwII_dU/discussion.

I've implemented it such that it will support BOTH vertical and horizontal native page scrolling. It only takes effect on touch devices so it won't affect desktop. I've allow taken precaution to make sure this doesn't affect the zoom functionality.

I've tested on iPhone (iOS 4 & 5), iPad (iOS 5), and Android 4 (on both phone and tablet).

Thanks!
