### PR TITLE
onMomentumStart, onMomentumMove, onMomentumEnd callbacks

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -325,7 +325,13 @@ iScroll.prototype = {
 
 		if (that.options.onBeforeScrollStart) that.options.onBeforeScrollStart.call(that, e);
 
-		if (that._isMomentumActive) that._isMomentumActive = false;
+		if (that._isMomentumActive)
+		{
+			that._isMomentumActive = false;
+			if (that.options.onMomentumEnd) that.options.onMomentumEnd.call(that);
+			if (that.options.onScrollEnd) that.options.onScrollEnd.call(that);
+		}
+
 		if (that.options.useTransition || that.options.zoom) that._transitionTime(0);
 
 		that.moved = false;


### PR DESCRIPTION
I've added 3 new options to iScroll that allow for additional events related to momentum. 

onMomentumStart fires if the momentum activates
onMomentumMove fires with each frame animation during the momentum cycle
onMomentumEnd fires when that animation completes

If a new move is started before momentum is completed, the internal _isMomentumActive boolean is reset to false.
