### PR TITLE
A quick three-line hack to make this work with IE8 and IE7

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -58,7 +58,7 @@ var m = Math,
 			i;
 
 		that.wrapper = typeof el == 'object' ? el : doc.getElementById(el);
-		that.wrapper.style.overflow = 'hidden';
+		that.wrapper.style.overflow = document.addEventListener ? 'hidden' : 'auto';
 		that.scroller = that.wrapper.children[0];
 
 		// Default options
@@ -845,11 +845,13 @@ iScroll.prototype = {
 	},
 
 	_bind: function (type, el, bubble) {
-		(el || this.scroller).addEventListener(type, this, !!bubble);
+		if((el || this.scroller).addEventListener)
+			(el || this.scroller).addEventListener(type, this, !!bubble);
 	},
 
 	_unbind: function (type, el, bubble) {
-		(el || this.scroller).removeEventListener(type, this, !!bubble);
+		if((el || this.scroller).addEventListener)
+			(el || this.scroller).removeEventListener(type, this, !!bubble);
 	},
 
 


### PR DESCRIPTION
A quick three-line hack to make this work with IE8 and IE7, and maybe some others where it failed before.
It simply does not fail when addEventListener doesn't exist, and uses overflow:auto in that case.
