### PR TITLE
Adding configuration option to define the minimum distance...

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -75,7 +75,8 @@ var m = Math,
 			useTransition: false,
 			topOffset: 0,
 			checkDOMChanges: false,		// Experimental
-      handleClick: true,
+			handleClick: true,
+			minDistance: 6,
 
 			// Scrollbar
 			hScrollbar: true,
@@ -434,7 +435,7 @@ iScroll.prototype = {
 		that.absDistX = m.abs(that.distX);
 		that.absDistY = m.abs(that.distY);
 
-		if (that.absDistX < 6 && that.absDistY < 6) {
+		if (that.absDistX < that.options.minDistance && that.absDistY < that.options.minDistance) {
 			return;
 		}
 


### PR DESCRIPTION
... that is needed to activate the scroll behaviour. The default was set to 6, accordingly to the iScroll default. This change improves the swiping behaviour when you have scrolling areas inside a swiping area (two dimensional scrolling with snap).
