### PR TITLE
Uncaught error

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -203,7 +203,7 @@ iScroll.prototype = {
 		if (!that[dir + 'Scrollbar']) {
 			if (that[dir + 'ScrollbarWrapper']) {
 				if (hasTransform) that[dir + 'ScrollbarIndicator'].style[vendor + 'Transform'] = '';
-				that[dir + 'ScrollbarWrapper'].parentNode.removeChild(that[dir + 'ScrollbarWrapper']);
+				if (that[dir + 'ScrollbarWrapper'].parentNode) that[dir + 'ScrollbarWrapper'].parentNode.removeChild(that[dir + 'ScrollbarWrapper']);
 				that[dir + 'ScrollbarWrapper'] = null;
 				that[dir + 'ScrollbarIndicator'] = null;
 			}


### PR DESCRIPTION
...lements.  It seems this function '_scrollbar' is called after a window resize event, and ScrollbarWrapper may be disconnected from the dom.  I haven't traversed the code enough to fully understand, but it seems we're just deleting the wrapper anyway.  This little check, fixes the uncaught error.
