### PR TITLE
Disable iScroll scrolling when touch specific element

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -39,6 +39,8 @@ var m = Math,
     hasTouch = 'ontouchstart' in window && !isTouchPad,
     hasTransform = !!vendor,
     hasTransitionEnd = prefixStyle('transition') in dummyStyle,
+    
+    stopOnTouch = '<SELECT><INPUT><TEXTAREA><BUTTON>',
 
 	RESIZE_EV = 'onorientationchange' in window ? 'orientationchange' : 'resize',
 	START_EV = hasTouch ? 'touchstart' : 'mousedown',
@@ -344,8 +346,9 @@ iScroll.prototype = {
 			point = hasTouch ? e.touches[0] : e,
 			matrix, x, y,
 			c1, c2;
-
-		if (!that.enabled) return;
+		
+		// Stops iscroll if touched a specific element
+		if (!that.enabled || stopOnTouch.match('<'+e.target.tagName+'>')) return;
 
 		if (that.options.onBeforeScrollStart) that.options.onBeforeScrollStart.call(that, e);
 


### PR DESCRIPTION
Hiya,

I implemented this to disable iscroll from scrolling when I touch a selected element that's specified in the script variable `stopOnTouch`. I'm not sure how elegant it is, but perhaps it might lead to some other sort of more elegant fix.

I understand a method could be implemented within the `onBeforeScrollStart` option but I wanted a generic base-level way of doing it as I don't see any situation in which I'd want a user to not be able to select a form field.

The `stopOnTouch` value could be relegated to `that.options` as well, rather than as a private script variable. I also opted for a string match (using angle brackets to match whole words) rather than separating each string item to match.

(Apologies for the weird commits; my first time figuring out github's social contribution stuff)

Matt
