### PR TITLE
cherry-pick to solve https://github.com/cubiq/iscroll/pull/198

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -177,7 +177,6 @@ var m = Math,
 		that._bind(RESIZE_EV, window);
 		that._bind(START_EV);
 		if (!hasTouch) {
-			that._bind('mouseout', that.wrapper);
 			if (that.options.wheelAction != 'none')
 				that._bind(WHEEL_EV);
 		}
@@ -211,7 +210,6 @@ iScroll.prototype = {
 			case CANCEL_EV: that._end(e); break;
 			case RESIZE_EV: that._resize(); break;
 			case WHEEL_EV: that._wheel(e); break;
-			case 'mouseout': that._mouseout(e); break;
 			case TRNEND_EV: that._transitionEnd(e); break;
 		}
 	},
@@ -404,9 +402,9 @@ iScroll.prototype = {
 
 		if (that.options.onScrollStart) that.options.onScrollStart.call(that, e);
 
-		that._bind(MOVE_EV);
-		that._bind(END_EV);
-		that._bind(CANCEL_EV);
+		that._bind(MOVE_EV, window);
+		that._bind(END_EV, window);
+		that._bind(CANCEL_EV, window);
 	},
 	
 	_move: function (e) {
@@ -506,9 +504,9 @@ iScroll.prototype = {
 			snap,
 			scale;
 
-		that._unbind(MOVE_EV);
-		that._unbind(END_EV);
-		that._unbind(CANCEL_EV);
+		that._unbind(MOVE_EV, window);
+		that._unbind(END_EV, window);
+		that._unbind(CANCEL_EV, window);
 
 		if (that.options.onBeforeScrollEnd) that.options.onBeforeScrollEnd.call(that, e);
 
@@ -700,19 +698,6 @@ iScroll.prototype = {
 		}
 	},
 	
-	_mouseout: function (e) {
-		var t = e.relatedTarget;
-
-		if (!t) {
-			this._end(e);
-			return;
-		}
-
-		while (t = t.parentNode) if (t == this.wrapper) return;
-		
-		this._end(e);
-	},
-
 	_transitionEnd: function (e) {
 		var that = this;
 
@@ -899,12 +884,11 @@ iScroll.prototype = {
 		// Remove the event listeners
 		that._unbind(RESIZE_EV, window);
 		that._unbind(START_EV);
-		that._unbind(MOVE_EV);
-		that._unbind(END_EV);
-		that._unbind(CANCEL_EV);
+		that._unbind(MOVE_EV, window);
+		that._unbind(END_EV, window);
+		that._unbind(CANCEL_EV, window);
 		
 		if (!that.options.hasTouch) {
-			that._unbind('mouseout', that.wrapper);
 			that._unbind(WHEEL_EV);
 		}
 		
@@ -1056,9 +1040,9 @@ iScroll.prototype = {
 		this.enabled = false;
 
 		// If disabled after touchstart we make sure that there are no left over events
-		this._unbind(MOVE_EV);
-		this._unbind(END_EV);
-		this._unbind(CANCEL_EV);
+		this._unbind(MOVE_EV, window);
+		this._unbind(END_EV, window);
+		this._unbind(CANCEL_EV, window);
 	},
 	
 	enable: function () {


### PR DESCRIPTION
If the containing box was small, it was hard to scroll at all.  Scrolling
should continue until the button is released, even if the mouse leaves
the window.
