### PR TITLE
Hack to prevent unwanted clicks in touch mode

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -214,7 +214,10 @@ iScroll.prototype = {
             while (target.nodeType != 1) target = target.parentNode;
 
             if (target.tagName != 'SELECT' && target.tagName != 'INPUT' && target.tagName != 'TEXTAREA')
+			{
+				e.stopPropagation();
                 e.preventDefault();
+			}
         }
         
 		switch(e.type) {


### PR DESCRIPTION
Android browser(and quite possibly others) occasionally sends its own, non-fake click event, even when touchstart event is canceled(i.e. preventDefault() is called). It happens often at first click on <a href="..."></a> link, and rarely in next clicks. When it happens, click is called twice - one for "fake click" generated by iScroll, one for "real click" generated by browser.

Events in running order:
touchstart
touchend
fake click
mousedown
mouseup
real click

This behavior leads to big problems in my code, since I intercept all clicked links with Java shouldOverrideUrl method and can't distinguish if user pressed link once or twice.

Only solution to this I found disabling "real click" event in "handleClick+hasTouch" mode. See commit. We don't need "real click" since we generate our own.
