### PR TITLE
Added ability to scroll horizontally by mouse wheel with wheelHorizontal = true option

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -666,9 +666,11 @@ iScroll.prototype = {
 		}
 
 		if (that.options.wheelHorizontal && vendor == 'webkit') {
-			wheelDeltaX = wheelDeltaY;
+			if (wheelDeltaY != 0) {
+				wheelDeltaX = wheelDeltaY;
+			}
 		}
-		
+
 		if (that.options.wheelAction == 'zoom') {
 			deltaScale = that.scale * Math.pow(2, 1/3 * (wheelDeltaY ? wheelDeltaY / Math.abs(wheelDeltaY) : 0));
 			if (deltaScale < that.options.zoomMin) deltaScale = that.options.zoomMin;


### PR DESCRIPTION
When using horizontal lists there was no support for mouse wheel.

Added check for option wheelHorizontal, and if it is set, _wheel() listener calls scrollTo() like with vertical scrolling and preventDefault() to stop browser from scroll other content vertically.
