### PR TITLE
Add prevent ghostclick functionality.

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -105,6 +105,8 @@ var m = Math,
 			topOffset: 0,
 			checkDOMChanges: false,		// Experimental
 			handleClick: true,
+			preventGhostClick: false,	// prevent ghost clicks?
+			ghostClickTimeout: 500,		// timeout for ghost click prevention
 
 			// Scrollbar
 			hScrollbar: true,
@@ -489,7 +491,22 @@ iScroll.prototype = {
 		if (that.options.onScrollMove) that.options.onScrollMove.call(that, e);
 	},
 	
+	/**
+	 * Prevents any real clicks.
+	 * See preventGhostClick portion of _end().
+	 */
+	_preventRealClick: function(e) {
+		if (e._fake !== true) {
+			e.preventDefault();
+			e.stopPropagation();
+			e.stopImmediatePropagation();
+			e.cancel = true;
+			return false;
+		}
+	},
+	
 	_end: function (e) {
+		var that = this;
 		if (hasTouch && e.touches.length !== 0) return;
 
 		var that = this,
@@ -559,6 +576,16 @@ iScroll.prototype = {
 								e.ctrlKey, e.altKey, e.shiftKey, e.metaKey,
 								0, null);
 							ev._fake = true;
+							
+							if (that.options.preventGhostClick) {
+								// prevent ghost real clicks on body
+								document.body.addEventListener('click', that._preventRealClick, true);
+								// until ghost click timeout expires
+								setTimeout(function () {
+									document.body.removeEventListener('click', that._preventRealClick, true);
+								}, that.options.ghostClickTimeout);
+							}
+							
 							target.dispatchEvent(ev);
 						}
 					}, that.options.zoom ? 250 : 0);


### PR DESCRIPTION
Adds option to prevent ghost click functionality, on an opt-in basis.

Fixes a multiple click event bug on default browser in Android Jelly Bean 4.1.
See: https://github.com/cubiq/iscroll/issues/270

Also see: https://github.com/cubiq/iscroll/issues/203

Similiar to: https://github.com/cubiq/iscroll/pull/263
but prevents clicks on document.body in addition to clicks on the same iScroll element.
