### PR TITLE
option to use mouse... events instead of touch... even if hasTouch.

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -41,10 +41,6 @@ var m = Math,
     hasTransitionEnd = prefixStyle('transition') in dummyStyle,
 
 	RESIZE_EV = 'onorientationchange' in window ? 'orientationchange' : 'resize',
-	START_EV = hasTouch ? 'touchstart' : 'mousedown',
-	MOVE_EV = hasTouch ? 'touchmove' : 'mousemove',
-	END_EV = hasTouch ? 'touchend' : 'mouseup',
-	CANCEL_EV = hasTouch ? 'touchcancel' : 'mouseup',
 	WHEEL_EV = vendor == 'Moz' ? 'DOMMouseScroll' : 'mousewheel',
 	TRNEND_EV = (function () {
 		if ( vendor === false ) return false;
@@ -125,6 +121,9 @@ var m = Math,
 			snap: false,
 			snapThreshold: 1,
 
+            // Event control
+            detectTouch: true,
+
 			// Events
 			onRefresh: null,
 			onBeforeScrollStart: function (e) { e.preventDefault(); },
@@ -142,7 +141,14 @@ var m = Math,
 
 		// User defined options
 		for (i in options) that.options[i] = options[i];
-		
+
+        // configuring events
+        that.useTouchEvents = (that.options.detectTouch &&  hasTouch);
+        that.START_EV = that.useTouchEvents? 'touchstart' : 'mousedown';
+        that.MOVE_EV = that.useTouchEvents ? 'touchmove' : 'mousemove';
+        that.END_EV = that.useTouchEvents ? 'touchend' : 'mouseup';
+        that.CANCEL_EV = that.useTouchEvents ? 'touchcancel' : 'mouseup';
+
 		// Set starting position
 		that.x = that.options.x;
 		that.y = that.options.y;
@@ -160,13 +166,13 @@ var m = Math,
 		if ( that.options.zoom && isAndroid ){
 			translateZ = '';
 		}
-		
+
 		// Set some default styles
 		that.scroller.style[transitionProperty] = that.options.useTransform ? cssVendor + 'transform' : 'top left';
 		that.scroller.style[transitionDuration] = '0';
 		that.scroller.style[transformOrigin] = '0 0';
 		if (that.options.useTransition) that.scroller.style[transitionTimingFunction] = 'cubic-bezier(0.33,0.66,0.66,1)';
-		
+
 		if (that.options.useTransform) that.scroller.style[transform] = 'translate(' + that.x + 'px,' + that.y + 'px)' + translateZ;
 		else that.scroller.style.cssText += ';position:absolute;top:' + that.y + 'px;left:' + that.x + 'px';
 
@@ -175,8 +181,8 @@ var m = Math,
 		that.refresh();
 
 		that._bind(RESIZE_EV, window);
-		that._bind(START_EV);
-		if (!hasTouch) {
+		that._bind(that.START_EV);
+		if (!that.useTouchEvents) {
 			if (that.options.wheelAction != 'none')
 				that._bind(WHEEL_EV);
 		}
@@ -197,30 +203,30 @@ iScroll.prototype = {
 	pagesX: [], pagesY: [],
 	aniTime: null,
 	wheelZoomCount: 0,
-	
+
 	handleEvent: function (e) {
 		var that = this;
 		switch(e.type) {
-			case START_EV:
-				if (!hasTouch && e.button !== 0) return;
+			case that.START_EV:
+				if (!that.useTouchEvents && e.button !== 0) return;
 				that._start(e);
 				break;
-			case MOVE_EV: that._move(e); break;
-			case END_EV:
-			case CANCEL_EV: that._end(e); break;
+			case that.MOVE_EV: that._move(e); break;
+			case that.END_EV:
+			case that.CANCEL_EV: that._end(e); break;
 			case RESIZE_EV: that._resize(); break;
 			case WHEEL_EV: that._wheel(e); break;
 			case TRNEND_EV: that._transitionEnd(e); break;
 		}
 	},
-	
+
 	_checkDOMChanges: function () {
 		if (this.moved || this.zoomed || this.animating ||
 			(this.scrollerW == this.scroller.offsetWidth * this.scale && this.scrollerH == this.scroller.offsetHeight * this.scale)) return;
 
 		this.refresh();
 	},
-	
+
 	_scrollbar: function (dir) {
 		var that = this,
 			bar;
@@ -277,12 +283,12 @@ iScroll.prototype = {
 		// Reset position
 		that._scrollbarPos(dir, true);
 	},
-	
+
 	_resize: function () {
 		var that = this;
 		setTimeout(function () { that.refresh(); }, isAndroid ? 200 : 0);
 	},
-	
+
 	_pos: function (x, y) {
 		if (this.zoomed) return;
 
@@ -336,10 +342,10 @@ iScroll.prototype = {
 		that[dir + 'ScrollbarWrapper'].style.opacity = hidden && that.options.hideScrollbar ? '0' : '1';
 		that[dir + 'ScrollbarIndicator'].style[transform] = 'translate(' + (dir == 'h' ? pos + 'px,0)' : '0,' + pos + 'px)') + translateZ;
 	},
-	
+
 	_start: function (e) {
 		var that = this,
-			point = hasTouch ? e.touches[0] : e,
+			point = that.useTouchEvents ? e.touches[0] : e,
 			matrix, x, y,
 			c1, c2;
 
@@ -360,7 +366,7 @@ iScroll.prototype = {
 		that.dirY = 0;
 
 		// Gesture start
-		if (that.options.zoom && hasTouch && e.touches.length > 1) {
+		if (that.options.zoom && that.useTouchEvents && e.touches.length > 1) {
 			c1 = m.abs(e.touches[0].pageX-e.touches[1].pageX);
 			c2 = m.abs(e.touches[0].pageY-e.touches[1].pageY);
 			that.touchesDistStart = m.sqrt(c1 * c1 + c2 * c2);
@@ -381,7 +387,7 @@ iScroll.prototype = {
 				x = +getComputedStyle(that.scroller, null).left.replace(/[^0-9-]/g, '');
 				y = +getComputedStyle(that.scroller, null).top.replace(/[^0-9-]/g, '');
 			}
-			
+
 			if (x != that.x || y != that.y) {
 				if (that.options.useTransition) that._unbind(TRNEND_EV);
 				else cancelFrame(that.aniTime);
@@ -403,14 +409,14 @@ iScroll.prototype = {
 
 		if (that.options.onScrollStart) that.options.onScrollStart.call(that, e);
 
-		that._bind(MOVE_EV, window);
-		that._bind(END_EV, window);
-		that._bind(CANCEL_EV, window);
+		that._bind(that.MOVE_EV, window);
+		that._bind(that.END_EV, window);
+		that._bind(that.CANCEL_EV, window);
 	},
-	
+
 	_move: function (e) {
 		var that = this,
-			point = hasTouch ? e.touches[0] : e,
+			point = that.useTouchEvents ? e.touches[0] : e,
 			deltaX = point.pageX - that.pointX,
 			deltaY = point.pageY - that.pointY,
 			newX = that.x + deltaX,
@@ -421,7 +427,7 @@ iScroll.prototype = {
 		if (that.options.onBeforeScrollMove) that.options.onBeforeScrollMove.call(that, e);
 
 		// Zoom
-		if (that.options.zoom && hasTouch && e.touches.length > 1) {
+		if (that.options.zoom && that.useTouchEvents && e.touches.length > 1) {
 			c1 = m.abs(e.touches[0].pageX - e.touches[1].pageX);
 			c2 = m.abs(e.touches[0].pageY - e.touches[1].pageY);
 			that.touchesDist = m.sqrt(c1*c1+c2*c2);
@@ -485,15 +491,15 @@ iScroll.prototype = {
 			that.startX = that.x;
 			that.startY = that.y;
 		}
-		
+
 		if (that.options.onScrollMove) that.options.onScrollMove.call(that, e);
 	},
-	
+
 	_end: function (e) {
-		if (hasTouch && e.touches.length !== 0) return;
+		if (this.useTouchEvents && e.touches.length !== 0) return;
 
 		var that = this,
-			point = hasTouch ? e.changedTouches[0] : e,
+			point = that.useTouchEvents ? e.changedTouches[0] : e,
 			target, ev,
 			momentumX = { dist:0, time:0 },
 			momentumY = { dist:0, time:0 },
@@ -505,9 +511,9 @@ iScroll.prototype = {
 			snap,
 			scale;
 
-		that._unbind(MOVE_EV, window);
-		that._unbind(END_EV, window);
-		that._unbind(CANCEL_EV, window);
+		that._unbind(that.MOVE_EV, window);
+		that._unbind(that.END_EV, window);
+		that._unbind(that.CANCEL_EV, window);
 
 		if (that.options.onBeforeScrollEnd) that.options.onBeforeScrollEnd.call(that, e);
 
@@ -520,10 +526,10 @@ iScroll.prototype = {
 
 			that.x = that.originX - that.originX * that.lastScale + that.x;
 			that.y = that.originY - that.originY * that.lastScale + that.y;
-			
+
 			that.scroller.style[transitionDuration] = '200ms';
 			that.scroller.style[transform] = 'translate(' + that.x + 'px,' + that.y + 'px) scale(' + that.scale + ')' + translateZ;
-			
+
 			that.zoomed = false;
 			that.refresh();
 
@@ -532,7 +538,7 @@ iScroll.prototype = {
 		}
 
 		if (!that.moved) {
-			if (hasTouch) {
+			if (that.useTouchEvents) {
 				if (that.doubleTapTimer && that.options.zoom) {
 					// Double tapped
 					clearTimeout(that.doubleTapTimer);
@@ -621,7 +627,7 @@ iScroll.prototype = {
 		that._resetPos(200);
 		if (that.options.onTouchEnd) that.options.onTouchEnd.call(that, e);
 	},
-	
+
 	_resetPos: function (time) {
 		var that = this,
 			resetX = that.x >= 0 ? 0 : that.x < that.maxScrollX ? that.maxScrollX : that.x,
@@ -664,27 +670,27 @@ iScroll.prototype = {
 		} else {
 			return;
 		}
-		
+
 		if (that.options.wheelAction == 'zoom') {
 			deltaScale = that.scale * Math.pow(2, 1/3 * (wheelDeltaY ? wheelDeltaY / Math.abs(wheelDeltaY) : 0));
 			if (deltaScale < that.options.zoomMin) deltaScale = that.options.zoomMin;
 			if (deltaScale > that.options.zoomMax) deltaScale = that.options.zoomMax;
-			
+
 			if (deltaScale != that.scale) {
 				if (!that.wheelZoomCount && that.options.onZoomStart) that.options.onZoomStart.call(that, e);
 				that.wheelZoomCount++;
-				
+
 				that.zoom(e.pageX, e.pageY, deltaScale, 400);
-				
+
 				setTimeout(function() {
 					that.wheelZoomCount--;
 					if (!that.wheelZoomCount && that.options.onZoomEnd) that.options.onZoomEnd.call(that, e);
 				}, 400);
 			}
-			
+
 			return;
 		}
-		
+
 		deltaX = that.x + wheelDeltaX;
 		deltaY = that.y + wheelDeltaY;
 
@@ -693,19 +699,19 @@ iScroll.prototype = {
 
 		if (deltaY > that.minScrollY) deltaY = that.minScrollY;
 		else if (deltaY < that.maxScrollY) deltaY = that.maxScrollY;
-    
+
 		if (that.maxScrollY < 0) {
 			that.scrollTo(deltaX, deltaY, 0);
 		}
 	},
-	
+
 	_transitionEnd: function (e) {
 		var that = this;
 
 		if (e.target != that.scroller) return;
 
 		that._unbind(TRNEND_EV);
-		
+
 		that._startAni();
 	},
 
@@ -723,19 +729,19 @@ iScroll.prototype = {
 			animate;
 
 		if (that.animating) return;
-		
+
 		if (!that.steps.length) {
 			that._resetPos(400);
 			return;
 		}
-		
+
 		step = that.steps.shift();
-		
+
 		if (step.x == startX && step.y == startY) step.time = 0;
 
 		that.animating = true;
 		that.moved = true;
-		
+
 		if (that.options.useTransition) {
 			that._transitionTime(step.time);
 			that._pos(step.x, step.y);
@@ -803,12 +809,12 @@ iScroll.prototype = {
 	_offset: function (el) {
 		var left = -el.offsetLeft,
 			top = -el.offsetTop;
-			
+
 		while (el = el.offsetParent) {
 			left -= el.offsetLeft;
 			top -= el.offsetTop;
 		}
-		
+
 		if (el != this.wrapper) {
 			left *= this.scale;
 			top *= this.scale;
@@ -884,19 +890,19 @@ iScroll.prototype = {
 
 		// Remove the event listeners
 		that._unbind(RESIZE_EV, window);
-		that._unbind(START_EV);
-		that._unbind(MOVE_EV, window);
-		that._unbind(END_EV, window);
-		that._unbind(CANCEL_EV, window);
-		
-		if (!that.options.hasTouch) {
+		that._unbind(that.START_EV);
+		that._unbind(that.MOVE_EV, window);
+		that._unbind(that.END_EV, window);
+		that._unbind(that.CANCEL_EV, window);
+
+		if (!that.useTouchEvents) {
 			that._unbind(WHEEL_EV);
 		}
-		
+
 		if (that.options.useTransition) that._unbind(TRNEND_EV);
-		
+
 		if (that.options.checkDOMChanges) clearInterval(that.checkDOMTime);
-		
+
 		if (that.options.onDestroy) that.options.onDestroy.call(that);
 	},
 
@@ -982,7 +988,7 @@ iScroll.prototype = {
 		that.stop();
 
 		if (!step.length) step = [{ x: x, y: y, time: time, relative: relative }];
-		
+
 		for (i=0, l=step.length; i<l; i++) {
 			if (step[i].relative) { step[i].x = that.x - step[i].x; step[i].y = that.y - step[i].y; }
 			that.steps.push({ x: step[i].x, y: step[i].y, time: step[i].time || 0 });
@@ -1009,7 +1015,7 @@ iScroll.prototype = {
 
 	scrollToPage: function (pageX, pageY, time) {
 		var that = this, x, y;
-		
+
 		time = time === undefined ? 400 : time;
 
 		if (that.options.onScrollStart) that.options.onScrollStart.call(that);
@@ -1041,15 +1047,15 @@ iScroll.prototype = {
 		this.enabled = false;
 
 		// If disabled after touchstart we make sure that there are no left over events
-		this._unbind(MOVE_EV, window);
-		this._unbind(END_EV, window);
-		this._unbind(CANCEL_EV, window);
+		this._unbind(this.MOVE_EV, window);
+		this._unbind(this.END_EV, window);
+		this._unbind(this.CANCEL_EV, window);
 	},
-	
+
 	enable: function () {
 		this.enabled = true;
 	},
-	
+
 	stop: function () {
 		if (this.options.useTransition) this._unbind(TRNEND_EV);
 		else cancelFrame(this.aniTime);
@@ -1057,7 +1063,7 @@ iScroll.prototype = {
 		this.moved = false;
 		this.animating = false;
 	},
-	
+
 	zoom: function (x, y, scale, time) {
 		var that = this,
 			relScale = scale / that.scale;
@@ -1081,7 +1087,7 @@ iScroll.prototype = {
 		that.scroller.style[transform] = 'translate(' + that.x + 'px,' + that.y + 'px) scale(' + scale + ')' + translateZ;
 		that.zoomed = false;
 	},
-	
+
 	isReady: function () {
 		return !this.moved && !this.zoomed && !this.animating;
 	}


### PR DESCRIPTION
Added detectTouch option - allows disabling the detection and binding standard mouse events. If you set detectTouch: false, it will not prefer touch events to mouse events, even if touch support is available. 
This actually makes it possible to use it for mouse-dragging in any (FF & Chrome?) browser without looking for a browser option to simulate touch events.
