### PR TITLE
IE 10 return "matrix3d" for "getComputedStyle(that.scroller, null)[transform]"

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -374,10 +374,13 @@ iScroll.prototype = {
 
 		if (that.options.momentum) {
 			if (that.options.useTransform) {
-				// Very lame general purpose alternative to CSSMatrix
-				matrix = getComputedStyle(that.scroller, null)[transform].replace(/[^0-9\-.,]/g, '').split(',');
-				x = +matrix[4];
-				y = +matrix[5];
+				var cssMatrix = getComputedStyle(that.scroller, null)[transform];
+	                        // Very lame general purpose alternative to CSSMatrix
+	                        matrix = cssMatrix.replace(/[^0-9\-.,]/g, '').split(',');
+	
+	                        x = (cssMatrix.indexOf("matrix3d") == 0) ? matrix[12] * 1 : matrix[4] * 1;
+	                        y = (cssMatrix.indexOf("matrix3d") == 0) ? matrix[13] * 1 : matrix[5] * 1;
+
 			} else {
 				x = +getComputedStyle(that.scroller, null).left.replace(/[^0-9-]/g, '');
 				y = +getComputedStyle(that.scroller, null).top.replace(/[^0-9-]/g, '');


### PR DESCRIPTION
IE 10 return "matrix3d" instead of "matrix" for "getComputedStyle(that.scroller, null)[transform]"

fixed the issue.
