### PR TITLE
Better desktop browser mouse wheel support

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -650,6 +650,10 @@ iScroll.prototype = {
 	},
 
 	_wheel: function (e) {
+		if (e.preventDefault) {
+			e.preventDefault();
+		}
+
 		var that = this,
 			wheelDeltaX, wheelDeltaY,
 			deltaX, deltaY,


### PR DESCRIPTION
Added a call to e.preventDefault() in the _wheel handler so that if you have an iScroll in a page with a scroll bar, it will scroll the iScroll region when the mouse is over it instead of the parent page.

Compatible with browsers supporting the DOM event 3 spec (IE9+ and all other modern browsers).
