### PR TITLE
Checking if iScroll is detached from the DOM

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -229,7 +229,7 @@ iScroll.prototype = {
 		if (!that[dir + 'Scrollbar']) {
 			if (that[dir + 'ScrollbarWrapper']) {
 				if (hasTransform) that[dir + 'ScrollbarIndicator'].style[transform] = '';
-				that[dir + 'ScrollbarWrapper'].parentNode.removeChild(that[dir + 'ScrollbarWrapper']);
+				if (that[dir + 'ScrollbarWrapper'].parentNode != undefined) that[dir + 'ScrollbarWrapper'].parentNode.removeChild(that[dir + 'ScrollbarWrapper']);
 				that[dir + 'ScrollbarWrapper'] = null;
 				that[dir + 'ScrollbarIndicator'] = null;
 			}


### PR DESCRIPTION
If we are working 'detached' from the DOM or the iScroll wrapper has been deleted, be sure that the `.destroy()` function is still working (error case: http://jsfiddle.net/NUK88/49/)
