### PR TITLE
Fix a bug

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -564,6 +564,15 @@ iScroll.prototype = {
 						}
 					}, that.options.zoom ? 250 : 0);
 				}
+				
+        // Do we need to snap?
+        if (that.options.snap) {
+            snap = that._snap(that.x, that.y);
+            if (snap.x != that.x || snap.y != that.y) that.scrollTo(snap.x, snap.y, snap.time);
+            
+            if (that.options.onTouchEnd) that.options.onTouchEnd.call(that, e);
+            return;
+        }
 			}
 
 			that._resetPos(400);


### PR DESCRIPTION
Sorry for my poor English...
When snap is enabled. If I touch move to the pos between 2 pages, the scroller will move to a page. But when it is moving (to a specific page), I touch on the scroller and don't move. when touch end, the original iScroll will stop between 2 pages.
