### PR TITLE
Fixed blurred content issue with iOS 5.

### DIFF
--- a/src/iscroll.js
+++ b/src/iscroll.js
@@ -35,7 +35,13 @@ var m = Math,
 	isIDevice = (/iphone|ipad/gi).test(navigator.appVersion),
 	isTouchPad = (/hp-tablet/gi).test(navigator.appVersion),
 
-    has3d = prefixStyle('perspective') in dummyStyle,
+    has3d = (function() {
+		var value = prefixStyle('perspective') in dummyStyle;
+		if (navigator.userAgent.match(/OS 5(_\d)+ like Mac OS X/i)) {
+			value = false;
+		}
+		return value;
+    })(),
     hasTouch = 'ontouchstart' in window && !isTouchPad,
     hasTransform = vendor !== false,
     hasTransitionEnd = prefixStyle('transition') in dummyStyle,


### PR DESCRIPTION
'translateZ(0)' causes the blurred content issue with iOS 5.

This code detects iOS 5 and disables 'translateZ(0)'.

related posts:

https://groups.google.com/forum/?fromgroups=#!searchin/iscroll/blur/iscroll/gU-UHFcxi8o/d0arMj5SqNEJ
https://groups.google.com/forum/?fromgroups=#!searchin/iscroll/retina/iscroll/DuZ5I-77fxo/wqZ9klysYgAJ
