### PR TITLE
make _wheelZoom work in Firefox

### DIFF
--- a/src/zoom/zoom.js
+++ b/src/zoom/zoom.js
@@ -150,7 +150,7 @@
 		} else if('wheelDelta' in e) {
 			wheelDeltaY = e.wheelDelta / Math.abs(e.wheelDelta);
 		} else if ('detail' in e) {
-			wheelDeltaY = -e.detail / Math.abs(e.wheelDelta);
+			wheelDeltaY = -e.detail / Math.abs(e.detail);
 		} else {
 			return;
 		}


### PR DESCRIPTION
This seems like a typo, so we changed it, and now wheel scrolling works in Firefox.
