### PR TITLE
Ignore unknown keys from making iScroll move somewhere

### DIFF
--- a/src/keys/keys.js
+++ b/src/keys/keys.js
@@ -94,7 +94,6 @@
 				
 			default:	/* return if key is unknown */
 				return;
-				break;
 		}
 
 		if ( snap ) {


### PR DESCRIPTION
For "snap" mode, when an unknown key is pressed, especially after initialization, if you already scrolled (by other means) to middle of scrollarea, any "unbound" key will move you back to the top of your scrollarea.
