### PR TITLE
Added support for unprefixed pointer events (required for IE11)

### DIFF
--- a/build/iscroll-lite.js
+++ b/build/iscroll-lite.js
@@ -154,7 +154,11 @@ var utils = (function () {
 
 		MSPointerDown: 3,
 		MSPointerMove: 3,
-		MSPointerUp: 3
+		MSPointerUp: 3,
+		
+		pointerdown: 3,
+		pointermove: 3,
+		pointerup: 3
 	});
 
 	me.extend(me.ease = {}, {
@@ -776,9 +780,13 @@ IScroll.prototype = {
 
 		if ( utils.hasPointer && !this.options.disablePointer ) {
 			eventType(this.wrapper, 'MSPointerDown', this);
+			eventType(this.wrapper, 'pointerdown', this);
 			eventType(target, 'MSPointerMove', this);
+			eventType(target, 'pointermove', this);
 			eventType(target, 'MSPointerCancel', this);
+			eventType(target, 'pointercancel', this);
 			eventType(target, 'MSPointerUp', this);
+			eventType(target, 'pointerup', this);
 		}
 
 		if ( utils.hasTouch && !this.options.disableTouch ) {
@@ -851,16 +859,19 @@ IScroll.prototype = {
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'MSPointerDown':
+			case 'pointerdown':
 			case 'mousedown':
 				this._start(e);
 				break;
 			case 'touchmove':
 			case 'MSPointerMove':
+			case 'pointermove':
 			case 'mousemove':
 				this._move(e);
 				break;
 			case 'touchend':
 			case 'MSPointerUp':
+			case 'pointerup':
 			case 'mouseup':
 			case 'touchcancel':
 			case 'MSPointerCancel':

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -154,7 +154,11 @@ var utils = (function () {
 
 		MSPointerDown: 3,
 		MSPointerMove: 3,
-		MSPointerUp: 3
+		MSPointerUp: 3,
+		
+		pointerdown: 3,
+		pointermove: 3,
+		pointerup: 3
 	});
 
 	me.extend(me.ease = {}, {
@@ -850,9 +854,13 @@ IScroll.prototype = {
 
 		if ( utils.hasPointer && !this.options.disablePointer ) {
 			eventType(this.wrapper, 'MSPointerDown', this);
+			eventType(this.wrapper, 'pointerdown', this);
 			eventType(target, 'MSPointerMove', this);
+			eventType(target, 'pointermove', this);
 			eventType(target, 'MSPointerCancel', this);
+			eventType(target, 'pointercancel', this);
 			eventType(target, 'MSPointerUp', this);
+			eventType(target, 'pointerup', this);
 		}
 
 		if ( utils.hasTouch && !this.options.disableTouch ) {
@@ -1460,16 +1468,19 @@ IScroll.prototype = {
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'MSPointerDown':
+			case 'pointerdown':
 			case 'mousedown':
 				this._start(e);
 				break;
 			case 'touchmove':
 			case 'MSPointerMove':
+			case 'pointermove':
 			case 'mousemove':
 				this._move(e);
 				break;
 			case 'touchend':
 			case 'MSPointerUp':
+			case 'pointerup':
 			case 'mouseup':
 			case 'touchcancel':
 			case 'MSPointerCancel':
@@ -1569,6 +1580,8 @@ function Indicator (scroller, options) {
 		if ( !this.options.disablePointer ) {
 			utils.addEvent(this.indicator, 'MSPointerDown', this);
 			utils.addEvent(window, 'MSPointerUp', this);
+			utils.addEvent(this.indicator, 'pointerdown', this);
+			utils.addEvent(window, 'pointerup', this);
 		}
 		if ( !this.options.disableMouse ) {
 			utils.addEvent(this.indicator, 'mousedown', this);
@@ -1582,19 +1595,23 @@ Indicator.prototype = {
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'MSPointerDown':
+			case 'pointerdown':
 			case 'mousedown':
 				this._start(e);
 				break;
 			case 'touchmove':
 			case 'MSPointerMove':
+			case 'pointermove':
 			case 'mousemove':
 				this._move(e);
 				break;
 			case 'touchend':
 			case 'MSPointerUp':
+			case 'pointerup':
 			case 'mouseup':
 			case 'touchcancel':
 			case 'MSPointerCancel':
+			case 'pointercancel':
 			case 'mousecancel':
 				this._end(e);
 				break;
@@ -1605,14 +1622,17 @@ Indicator.prototype = {
 		if ( this.options.interactive ) {
 			utils.removeEvent(this.indicator, 'touchstart', this);
 			utils.removeEvent(this.indicator, 'MSPointerDown', this);
+			utils.removeEvent(this.indicator, 'pointerdown', this);
 			utils.removeEvent(this.indicator, 'mousedown', this);
 
 			utils.removeEvent(window, 'touchmove', this);
 			utils.removeEvent(window, 'MSPointerMove', this);
+			utils.removeEvent(window, 'pointermove', this);
 			utils.removeEvent(window, 'mousemove', this);
 
 			utils.removeEvent(window, 'touchend', this);
 			utils.removeEvent(window, 'MSPointerUp', this);
+			utils.removeEvent(window, 'pointerup', this);
 			utils.removeEvent(window, 'mouseup', this);
 		}
 
@@ -1641,6 +1661,7 @@ Indicator.prototype = {
 		}
 		if ( !this.options.disablePointer ) {
 			utils.addEvent(window, 'MSPointerMove', this);
+			utils.addEvent(window, 'pointermove', this);
 		}
 		if ( !this.options.disableMouse ) {
 			utils.addEvent(window, 'mousemove', this);
@@ -1688,6 +1709,7 @@ Indicator.prototype = {
 
 		utils.removeEvent(window, 'touchmove', this);
 		utils.removeEvent(window, 'MSPointerMove', this);
+		utils.removeEvent(window, 'pointermove', this);
 		utils.removeEvent(window, 'mousemove', this);
 
 		if ( this.scroller.options.snap ) {

--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -154,7 +154,11 @@ var utils = (function () {
 
 		MSPointerDown: 3,
 		MSPointerMove: 3,
-		MSPointerUp: 3
+		MSPointerUp: 3,
+		
+		pointerdown: 3,
+		pointermove: 3,
+		pointerup: 3
 	});
 
 	me.extend(me.ease = {}, {
@@ -844,9 +848,13 @@ IScroll.prototype = {
 
 		if ( utils.hasPointer && !this.options.disablePointer ) {
 			eventType(this.wrapper, 'MSPointerDown', this);
+			eventType(this.wrapper, 'pointerdown', this);
 			eventType(target, 'MSPointerMove', this);
+			eventType(target, 'pointermove', this);
 			eventType(target, 'MSPointerCancel', this);
+			eventType(target, 'pointercancel', this);
 			eventType(target, 'MSPointerUp', this);
+			eventType(target, 'pointerup', this);
 		}
 
 		if ( utils.hasTouch && !this.options.disableTouch ) {
@@ -1613,6 +1621,7 @@ IScroll.prototype = {
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'MSPointerDown':
+			case 'pointerdown':
 			case 'mousedown':
 				this._start(e);
 
@@ -1622,6 +1631,7 @@ IScroll.prototype = {
 				break;
 			case 'touchmove':
 			case 'MSPointerMove':
+			case 'pointermove':
 			case 'mousemove':
 				if ( this.options.zoom && e.touches && e.touches[1] ) {
 					this._zoom(e);
@@ -1631,9 +1641,11 @@ IScroll.prototype = {
 				break;
 			case 'touchend':
 			case 'MSPointerUp':
+			case 'pointerup':
 			case 'mouseup':
 			case 'touchcancel':
 			case 'MSPointerCancel':
+			case 'pointercancel':
 			case 'mousecancel':
 				if ( this.scaled ) {
 					this._zoomEnd(e);
@@ -1733,6 +1745,8 @@ function Indicator (scroller, options) {
 		if ( !this.options.disablePointer ) {
 			utils.addEvent(this.indicator, 'MSPointerDown', this);
 			utils.addEvent(window, 'MSPointerUp', this);
+			utils.addEvent(this.indicator, 'pointerdown', this);
+			utils.addEvent(window, 'pointerup', this);
 		}
 		if ( !this.options.disableMouse ) {
 			utils.addEvent(this.indicator, 'mousedown', this);
@@ -1746,19 +1760,23 @@ Indicator.prototype = {
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'MSPointerDown':
+			case 'pointerdown':
 			case 'mousedown':
 				this._start(e);
 				break;
 			case 'touchmove':
 			case 'MSPointerMove':
+			case 'pointermove':
 			case 'mousemove':
 				this._move(e);
 				break;
 			case 'touchend':
 			case 'MSPointerUp':
+			case 'pointerup':
 			case 'mouseup':
 			case 'touchcancel':
 			case 'MSPointerCancel':
+			case 'pointercancel':
 			case 'mousecancel':
 				this._end(e);
 				break;
@@ -1769,14 +1787,17 @@ Indicator.prototype = {
 		if ( this.options.interactive ) {
 			utils.removeEvent(this.indicator, 'touchstart', this);
 			utils.removeEvent(this.indicator, 'MSPointerDown', this);
+			utils.removeEvent(this.indicator, 'pointerdown', this);
 			utils.removeEvent(this.indicator, 'mousedown', this);
 
 			utils.removeEvent(window, 'touchmove', this);
 			utils.removeEvent(window, 'MSPointerMove', this);
+			utils.removeEvent(window, 'pointermove', this);
 			utils.removeEvent(window, 'mousemove', this);
 
 			utils.removeEvent(window, 'touchend', this);
 			utils.removeEvent(window, 'MSPointerUp', this);
+			utils.removeEvent(window, 'pointerup', this);
 			utils.removeEvent(window, 'mouseup', this);
 		}
 
@@ -1805,6 +1826,7 @@ Indicator.prototype = {
 		}
 		if ( !this.options.disablePointer ) {
 			utils.addEvent(window, 'MSPointerMove', this);
+			utils.addEvent(window, 'pointermove', this);
 		}
 		if ( !this.options.disableMouse ) {
 			utils.addEvent(window, 'mousemove', this);
@@ -1852,6 +1874,7 @@ Indicator.prototype = {
 
 		utils.removeEvent(window, 'touchmove', this);
 		utils.removeEvent(window, 'MSPointerMove', this);
+		utils.removeEvent(window, 'pointermove', this);
 		utils.removeEvent(window, 'mousemove', this);
 
 		if ( this.scroller.options.snap ) {

--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -154,7 +154,11 @@ var utils = (function () {
 
 		MSPointerDown: 3,
 		MSPointerMove: 3,
-		MSPointerUp: 3
+		MSPointerUp: 3,
+		
+		pointerdown: 3,
+		pointermove: 3,
+		pointerup: 3
 	});
 
 	me.extend(me.ease = {}, {
@@ -841,9 +845,13 @@ IScroll.prototype = {
 
 		if ( utils.hasPointer && !this.options.disablePointer ) {
 			eventType(this.wrapper, 'MSPointerDown', this);
+			eventType(this.wrapper, 'pointerdown', this);
 			eventType(target, 'MSPointerMove', this);
+			eventType(target, 'pointermove', this);
 			eventType(target, 'MSPointerCancel', this);
+			eventType(target, 'pointercancel', this);
 			eventType(target, 'MSPointerUp', this);
+			eventType(target, 'pointerup', this);
 		}
 
 		if ( utils.hasTouch && !this.options.disableTouch ) {
@@ -1442,16 +1450,19 @@ IScroll.prototype = {
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'MSPointerDown':
+			case 'pointerdown':
 			case 'mousedown':
 				this._start(e);
 				break;
 			case 'touchmove':
 			case 'MSPointerMove':
+			case 'pointermove':
 			case 'mousemove':
 				this._move(e);
 				break;
 			case 'touchend':
 			case 'MSPointerUp':
+			case 'pointerup':
 			case 'mouseup':
 			case 'touchcancel':
 			case 'MSPointerCancel':
@@ -1551,6 +1562,8 @@ function Indicator (scroller, options) {
 		if ( !this.options.disablePointer ) {
 			utils.addEvent(this.indicator, 'MSPointerDown', this);
 			utils.addEvent(window, 'MSPointerUp', this);
+			utils.addEvent(this.indicator, 'pointerdown', this);
+			utils.addEvent(window, 'pointerup', this);
 		}
 		if ( !this.options.disableMouse ) {
 			utils.addEvent(this.indicator, 'mousedown', this);
@@ -1564,19 +1577,23 @@ Indicator.prototype = {
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'MSPointerDown':
+			case 'pointerdown':
 			case 'mousedown':
 				this._start(e);
 				break;
 			case 'touchmove':
 			case 'MSPointerMove':
+			case 'pointermove':
 			case 'mousemove':
 				this._move(e);
 				break;
 			case 'touchend':
 			case 'MSPointerUp':
+			case 'pointerup':
 			case 'mouseup':
 			case 'touchcancel':
 			case 'MSPointerCancel':
+			case 'pointercancel':
 			case 'mousecancel':
 				this._end(e);
 				break;
@@ -1587,14 +1604,17 @@ Indicator.prototype = {
 		if ( this.options.interactive ) {
 			utils.removeEvent(this.indicator, 'touchstart', this);
 			utils.removeEvent(this.indicator, 'MSPointerDown', this);
+			utils.removeEvent(this.indicator, 'pointerdown', this);
 			utils.removeEvent(this.indicator, 'mousedown', this);
 
 			utils.removeEvent(window, 'touchmove', this);
 			utils.removeEvent(window, 'MSPointerMove', this);
+			utils.removeEvent(window, 'pointermove', this);
 			utils.removeEvent(window, 'mousemove', this);
 
 			utils.removeEvent(window, 'touchend', this);
 			utils.removeEvent(window, 'MSPointerUp', this);
+			utils.removeEvent(window, 'pointerup', this);
 			utils.removeEvent(window, 'mouseup', this);
 		}
 
@@ -1623,6 +1643,7 @@ Indicator.prototype = {
 		}
 		if ( !this.options.disablePointer ) {
 			utils.addEvent(window, 'MSPointerMove', this);
+			utils.addEvent(window, 'pointermove', this);
 		}
 		if ( !this.options.disableMouse ) {
 			utils.addEvent(window, 'mousemove', this);
@@ -1670,6 +1691,7 @@ Indicator.prototype = {
 
 		utils.removeEvent(window, 'touchmove', this);
 		utils.removeEvent(window, 'MSPointerMove', this);
+		utils.removeEvent(window, 'pointermove', this);
 		utils.removeEvent(window, 'mousemove', this);
 
 		if ( this.scroller.options.snap ) {


### PR DESCRIPTION
With internet explorer 11, it no longer supports the MS prefixed pointer events. Instead, it supports the unprefixed version.

This pull request adds support for the unprefixed version of the events.
