### PR TITLE
android : fix double click events sent by the stock Android 4.0.x browse...

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -284,7 +284,7 @@ IScroll.prototype = {
 				utils.tap(e, this.options.tap);
 			}
 
-			if ( this.options.click ) {
+			if ( this.options.click && !utils.isAndroidBrowser ) {
 				utils.click(e);
 			}
 
@@ -530,7 +530,7 @@ IScroll.prototype = {
 		eventType(window, 'orientationchange', this);
 		eventType(window, 'resize', this);
 
-		if ( this.options.click ) {
+		if ( this.options.click && !utils.isAndroidBrowser ) {
 			eventType(this.wrapper, 'click', this, true);
 		}
 


### PR DESCRIPTION
if using click: true so that you can enable clicks on elements inside the scroller, the bad Android 4.0 stock browser will send two click events, triggered by two mousecancel events. Chrome for Android 4 works fine, and stock Android > 4.0 seem unaffected.

this is bad because if the element you clicked on creates another element listening for clicks (for ex. a popup), it will receive an unexpected second click

pr : fix double click events sent by the stock Android 4.0.x browser. Bug can be reproduced on a 4.0 Samsung Galaxy S2
