### PR TITLE
patch acceptance notice in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,11 @@
-# Contributing to iScroll
+# Contributing to iScroll / FAQ
+
+## Why is my patch not accepted?
+Thank you very much for your contribution. Please make sure you signed the CLA (see below). Also, we have to test every change on countless devices before we can add it to the project. Often one fix for one device breaks a lof of stuff for others. Unlike other open-source projects, we don't have the luxury of being able to unit test changes. A lot of manual testing is involved. Please be patient with us.
+
+If you want to speed up the process, please provide your own test results and try to be as specific as possible.
+
+## Why we need a CLA (Contributor License Agreement)
 
 All contributions are welcome but to enforce the openess of this script I have to ask all contributors to sign a Contributor License Agreement. I'm sorry about this but it's the only way to keep the script free and Open Source.
 


### PR DESCRIPTION
Letting people know why their patch is not accepted immediately. FAQ-style contributing.md. Extendable in the future.
