### PR TITLE
Change off's behavior: If fn is not given, all event handlers of given t...

### DIFF
--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -721,11 +721,15 @@ IScroll.prototype = {
 			return;
 		}
 
-		var index = this._events[type].indexOf(fn);
+        if(fn) {
+            var index = this._events[type].indexOf(fn);
 
-		if ( index > -1 ) {
-			this._events[type].splice(index, 1);
-		}
+            if ( index > -1 ) {
+                this._events[type].splice(index, 1);
+            }
+        } else {
+            delete this._events[type];
+        }
 	},
 
 	_execEvent: function (type) {

--- a/build/iscroll-lite.js
+++ b/build/iscroll-lite.js
@@ -661,11 +661,15 @@ IScroll.prototype = {
 			return;
 		}
 
-		var index = this._events[type].indexOf(fn);
+        if(fn) {
+            var index = this._events[type].indexOf(fn);
 
-		if ( index > -1 ) {
-			this._events[type].splice(index, 1);
-		}
+            if ( index > -1 ) {
+                this._events[type].splice(index, 1);
+            }
+        } else {
+            delete this._events[type];
+        }
 	},
 
 	_execEvent: function (type) {

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -715,11 +715,15 @@ IScroll.prototype = {
 			return;
 		}
 
-		var index = this._events[type].indexOf(fn);
+        if(fn) {
+            var index = this._events[type].indexOf(fn);
 
-		if ( index > -1 ) {
-			this._events[type].splice(index, 1);
-		}
+            if ( index > -1 ) {
+                this._events[type].splice(index, 1);
+            }
+        } else {
+            delete this._events[type];
+        }
 	},
 
 	_execEvent: function (type) {

--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -713,11 +713,15 @@ IScroll.prototype = {
 			return;
 		}
 
-		var index = this._events[type].indexOf(fn);
+        if(fn) {
+            var index = this._events[type].indexOf(fn);
 
-		if ( index > -1 ) {
-			this._events[type].splice(index, 1);
-		}
+            if ( index > -1 ) {
+                this._events[type].splice(index, 1);
+            }
+        } else {
+            delete this._events[type];
+        }
 	},
 
 	_execEvent: function (type) {

--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -706,11 +706,15 @@ IScroll.prototype = {
 			return;
 		}
 
-		var index = this._events[type].indexOf(fn);
+        if(fn) {
+            var index = this._events[type].indexOf(fn);
 
-		if ( index > -1 ) {
-			this._events[type].splice(index, 1);
-		}
+            if ( index > -1 ) {
+                this._events[type].splice(index, 1);
+            }
+        } else {
+            delete this._events[type];
+        }
 	},
 
 	_execEvent: function (type) {

--- a/src/core.js
+++ b/src/core.js
@@ -425,11 +425,15 @@ IScroll.prototype = {
 			return;
 		}
 
-		var index = this._events[type].indexOf(fn);
+        if(fn) {
+            var index = this._events[type].indexOf(fn);
 
-		if ( index > -1 ) {
-			this._events[type].splice(index, 1);
-		}
+            if ( index > -1 ) {
+                this._events[type].splice(index, 1);
+            }
+        } else {
+            delete this._events[type];
+        }
 	},
 
 	_execEvent: function (type) {


### PR DESCRIPTION
Sometimes when we using on to register a callback, the function usually have no name.
So I need a method to unregister all callbacks of given type.

In jQuery, when no function is given, all handlers of given type will be unregistered, which I consider useful.
So I implement it in iScroll, hopefully can be accepted.
