### PR TITLE
FIXED a bug with two infinite-iscrolls on a page; that would calculate the wrong wrapper height.

### DIFF
--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -1411,8 +1411,9 @@ IScroll.prototype = {
 
 	_initInfinite: function () {
 		var el = this.options.infiniteElements;
+        var root = this.wrapper || document;
 
-		this.infiniteElements = typeof el == 'string' ? document.querySelectorAll(el) : el;
+		this.infiniteElements = typeof el == 'string' ? root.querySelectorAll(el) : el;
 		this.infiniteLength = this.infiniteElements.length;
 		this.infiniteMaster = this.infiniteElements[0];
 		this.infiniteElementHeight = this.infiniteMaster.offsetHeight;

--- a/src/infinite/infinite.js
+++ b/src/infinite/infinite.js
@@ -1,8 +1,9 @@
 
 	_initInfinite: function () {
 		var el = this.options.infiniteElements;
+        var root = this.wrapper || document;
 
-		this.infiniteElements = typeof el == 'string' ? document.querySelectorAll(el) : el;
+		this.infiniteElements = typeof el == 'string' ? root.querySelectorAll(el) : el;
 		this.infiniteLength = this.infiniteElements.length;
 		this.infiniteMaster = this.infiniteElements[0];
 		this.infiniteElementHeight = this.infiniteMaster.offsetHeight;


### PR DESCRIPTION
FIXED a bug with two infinite-iscrolls on a page, that would calculate the wrong wrapper height. It should now default to the root element/ wrapper for the IScroll before finding the infiniteElements ( list/ row ).
