### PR TITLE
Check Indicators-array existence before iterating over it

### DIFF
--- a/src/indicator/_initIndicators.js
+++ b/src/indicator/_initIndicators.js
@@ -56,9 +56,10 @@
 
 		// TODO: check if we can use array.map (wide compatibility and performance issues)
 		function _indicatorsMap (fn) {
-			for ( var i = that.indicators.length; i--; ) {
-				fn.call(that.indicators[i]);
-			}
+			if( that.indicators )
+				for ( var i = that.indicators.length; i--; ) {
+					fn.call(that.indicators[i]);
+				}
 		}
 
 		if ( this.options.fadeScrollbars ) {


### PR DESCRIPTION
Sometimes `_indicatorsMap()` is called after `destroy()` has already been called.

One case I managed to track down was when the instance was destroyed on the `window.resize` event:

The instance still handles the event and tries to `refresh()`, which in turn calls `_indicatorsMap` which iterates over `that.indicators`. But `destroy` already `delete`'d the indicators array.

```
this.on('destroy', function () {
    // ...
    delete this.indicators;
});
```
