### PR TITLE
triggering touchEnd event

### DIFF
--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -522,7 +522,7 @@ IScroll.prototype = {
 			e.preventDefault();
 		}
 
-		this._execEvent('touchEnd');
+		this._execEvent('beforeScrollEnd');
 
 		var point = e.changedTouches ? e.changedTouches[0] : e,
 			momentumX,

--- a/src/core.js
+++ b/src/core.js
@@ -258,7 +258,7 @@ IScroll.prototype = {
 			e.preventDefault();
 		}
 
-		this._execEvent('touchEnd');
+		this._execEvent('beforeScrollEnd');
 
 		var point = e.changedTouches ? e.changedTouches[0] : e,
 			momentumX,


### PR DESCRIPTION
I needed to disable iScroll after the touch had ended and only enable it again on scrollEnd.
Now my component only starts a new scroll after the current one ends.
