### PR TITLE
Add 'forceBounce' options

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,15 @@ Duration in millisecond of the bounce animation.
 
 Default: `600`
 
+
+### <small>options.</small>forceBounce
+
+Force bounce effect even when the scroll container (wrapper) fits into the scrolling area.
+
+Note that enabling `forceBounce` options set `bounce` option to `true`.
+
+Default: `false`
+
 ### <small>options.</small>deceleration
 
 This value can be altered to change the momentum animation duration/speed. Higher numbers make the animation shorter. Sensible results can be experienced starting with a value of `0.01`, bigger than that basically doesn't make any momentum at all.

--- a/src/core.js
+++ b/src/core.js
@@ -55,6 +55,11 @@ function IScroll (el, options) {
 		this.options.tap = 'tap';
 	}
 
+  // If we forceBounce, bounce is automatically set to true
+  if ( this.options.forceBounce === true ) {
+    this.options.bounce = true
+   }
+
 // INSERT POINT: NORMALIZATION
 
 	// Some defaults	
@@ -212,8 +217,9 @@ IScroll.prototype = {
 			deltaX = 0;
 		}
 
-		deltaX = this.hasHorizontalScroll ? deltaX : 0;
-		deltaY = this.hasVerticalScroll ? deltaY : 0;
+    // Keep delta value if it has scroll or forceBounce is true
+		deltaX = this.hasHorizontalScroll || (this.options.forceBounce && this.options.scrollY)? deltaX : 0;
+		deltaY = this.hasVerticalScroll   || (this.options.forceBounce && this.options.scrollY)? deltaY : 0;
 
 		newX = this.x + deltaX;
 		newY = this.y + deltaY;


### PR DESCRIPTION
Add 'forceBounce' options to force bounce effect even when the scroll container fits into the scrolling area, and update documentation according to modifications.