### PR TITLE
Fix bug that checkboxes cannot be clicked on. These changes are to allow...

### DIFF
--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -216,11 +216,11 @@ var utils = (function () {
 		e.target.dispatchEvent(ev);
 	};
 
-	me.click = function (e) {
+	me.click = function (e, clickFilter) {
 		var target = e.target,
 			ev;
 
-		if ( !(/(SELECT|INPUT|TEXTAREA)/i).test(target.tagName) ) {
+		if ( !clickFilter.test(target.tagName) ) {
 			ev = document.createEvent('MouseEvents');
 			ev.initMouseEvent('click', true, true, e.view, 1,
 				target.screenX, target.screenY, target.clientX, target.clientY,
@@ -263,6 +263,7 @@ function IScroll (el, options) {
 
 		preventDefault: true,
 		preventDefaultException: { tagName: /^(INPUT|TEXTAREA|BUTTON|SELECT)$/ },
+        clickFilter: (/(SELECT|INPUT|TEXTAREA)/i),
 
 		HWCompositing: true,
 		useTransition: true,
@@ -562,7 +563,7 @@ IScroll.prototype = {
 			}
 
 			if ( this.options.click ) {
-				utils.click(e);
+				utils.click(e, this.options.clickFilter);
 			}
 
 			this._execEvent('scrollCancel');

--- a/build/iscroll-lite.js
+++ b/build/iscroll-lite.js
@@ -216,11 +216,11 @@ var utils = (function () {
 		e.target.dispatchEvent(ev);
 	};
 
-	me.click = function (e) {
+	me.click = function (e, clickFilter) {
 		var target = e.target,
 			ev;
 
-		if ( !(/(SELECT|INPUT|TEXTAREA)/i).test(target.tagName) ) {
+		if ( !clickFilter.test(target.tagName) ) {
 			ev = document.createEvent('MouseEvents');
 			ev.initMouseEvent('click', true, true, e.view, 1,
 				target.screenX, target.screenY, target.clientX, target.clientY,
@@ -256,6 +256,7 @@ function IScroll (el, options) {
 
 		preventDefault: true,
 		preventDefaultException: { tagName: /^(INPUT|TEXTAREA|BUTTON|SELECT)$/ },
+        clickFilter: (/(SELECT|INPUT|TEXTAREA)/i),
 
 		HWCompositing: true,
 		useTransition: true,
@@ -523,7 +524,7 @@ IScroll.prototype = {
 			}
 
 			if ( this.options.click ) {
-				utils.click(e);
+				utils.click(e, this.options.clickFilter);
 			}
 
 			this._execEvent('scrollCancel');

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -216,11 +216,11 @@ var utils = (function () {
 		e.target.dispatchEvent(ev);
 	};
 
-	me.click = function (e) {
+	me.click = function (e, clickFilter) {
 		var target = e.target,
 			ev;
 
-		if ( !(/(SELECT|INPUT|TEXTAREA)/i).test(target.tagName) ) {
+		if ( !clickFilter.test(target.tagName) ) {
 			ev = document.createEvent('MouseEvents');
 			ev.initMouseEvent('click', true, true, e.view, 1,
 				target.screenX, target.screenY, target.clientX, target.clientY,
@@ -262,6 +262,7 @@ function IScroll (el, options) {
 
 		preventDefault: true,
 		preventDefaultException: { tagName: /^(INPUT|TEXTAREA|BUTTON|SELECT)$/ },
+        clickFilter: (/(SELECT|INPUT|TEXTAREA)/i),
 
 		HWCompositing: true,
 		useTransition: true,
@@ -560,7 +561,7 @@ IScroll.prototype = {
 			}
 
 			if ( this.options.click ) {
-				utils.click(e);
+				utils.click(e, this.options.clickFilter);
 			}
 
 			this._execEvent('scrollCancel');

--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -216,11 +216,11 @@ var utils = (function () {
 		e.target.dispatchEvent(ev);
 	};
 
-	me.click = function (e) {
+	me.click = function (e, clickFilter) {
 		var target = e.target,
 			ev;
 
-		if ( !(/(SELECT|INPUT|TEXTAREA)/i).test(target.tagName) ) {
+		if ( !clickFilter.test(target.tagName) ) {
 			ev = document.createEvent('MouseEvents');
 			ev.initMouseEvent('click', true, true, e.view, 1,
 				target.screenX, target.screenY, target.clientX, target.clientY,
@@ -265,6 +265,7 @@ function IScroll (el, options) {
 
 		preventDefault: true,
 		preventDefaultException: { tagName: /^(INPUT|TEXTAREA|BUTTON|SELECT)$/ },
+        clickFilter: (/(SELECT|INPUT|TEXTAREA)/i),
 
 		HWCompositing: true,
 		useTransition: true,
@@ -560,7 +561,7 @@ IScroll.prototype = {
 			}
 
 			if ( this.options.click ) {
-				utils.click(e);
+				utils.click(e, this.options.clickFilter);
 			}
 
 			this._execEvent('scrollCancel');

--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -216,11 +216,11 @@ var utils = (function () {
 		e.target.dispatchEvent(ev);
 	};
 
-	me.click = function (e) {
+	me.click = function (e, clickFilter) {
 		var target = e.target,
 			ev;
 
-		if ( !(/(SELECT|INPUT|TEXTAREA)/i).test(target.tagName) ) {
+		if ( !clickFilter.test(target.tagName) ) {
 			ev = document.createEvent('MouseEvents');
 			ev.initMouseEvent('click', true, true, e.view, 1,
 				target.screenX, target.screenY, target.clientX, target.clientY,
@@ -262,6 +262,7 @@ function IScroll (el, options) {
 
 		preventDefault: true,
 		preventDefaultException: { tagName: /^(INPUT|TEXTAREA|BUTTON|SELECT)$/ },
+        clickFilter: (/(SELECT|INPUT|TEXTAREA)/i),
 
 		HWCompositing: true,
 		useTransition: true,
@@ -551,7 +552,7 @@ IScroll.prototype = {
 			}
 
 			if ( this.options.click ) {
-				utils.click(e);
+				utils.click(e, this.options.clickFilter);
 			}
 
 			this._execEvent('scrollCancel');

--- a/src/core.js
+++ b/src/core.js
@@ -20,6 +20,7 @@ function IScroll (el, options) {
 
 		preventDefault: true,
 		preventDefaultException: { tagName: /^(INPUT|TEXTAREA|BUTTON|SELECT)$/ },
+        clickFilter: (/(SELECT|INPUT|TEXTAREA)/i),
 
 		HWCompositing: true,
 		useTransition: true,
@@ -287,7 +288,7 @@ IScroll.prototype = {
 			}
 
 			if ( this.options.click ) {
-				utils.click(e);
+				utils.click(e, this.options.clickFilter);
 			}
 
 			this._execEvent('scrollCancel');

--- a/src/utils.js
+++ b/src/utils.js
@@ -214,11 +214,11 @@ var utils = (function () {
 		e.target.dispatchEvent(ev);
 	};
 
-	me.click = function (e) {
+	me.click = function (e, clickFilter) {
 		var target = e.target,
 			ev;
 
-		if ( !(/(SELECT|INPUT|TEXTAREA)/i).test(target.tagName) ) {
+		if ( !clickFilter.test(target.tagName) ) {
 			ev = document.createEvent('MouseEvents');
 			ev.initMouseEvent('click', true, true, e.view, 1,
 				target.screenX, target.screenY, target.clientX, target.clientY,


### PR DESCRIPTION
https://github.com/cubiq/iscroll/issues/640

... the click filter to be overridden on an iscroll instance. This does not change the iscroll behavior, it just makes configurable a hard coded piece of the code.

clickFilter was added to options with the hard coded regex so that it can be overridden.

now you just pass to iScroll the change in the click filter.

{click:true, clickFilter: (/(SELECT|TEXTAREA)/i)}

it was 

{click:true, clickFilter: (/(SELECT|INPUT|TEXTAREA)/i)}

But I wanted a checkbox to be clickable in this scrollable area (like a terms and conditions). It isn't specific to checkbox, this allows customization over what can be clicked by the developer.
