### PR TITLE
Android 2.3 dont have Function.prototype.bind

### DIFF
--- a/src/indicator/indicator.js
+++ b/src/indicator/indicator.js
@@ -1,4 +1,3 @@
-
 function createDefaultScrollbar (direction, interactive, type) {
 	var scrollbar = document.createElement('div'),
 		indicator = document.createElement('div');
@@ -395,7 +394,7 @@ Indicator.prototype = {
 	},
 
 	fade: function (val, hold) {
-		if ( hold && !this.visible ) {
+		if ( hold && !this.visible || utils.isBadAndroid ) {
 			return;
 		}
 


### PR DESCRIPTION
Android's 2.3 browser doesnt have Function.prototype.bind (checked on http://kangax.github.io/es5-compat-table/#Function.prototype.bind). 
I fixed problem in my application by adding return if utils.isBadAndroid is true.
