### PR TITLE
Oversized scroller causes snap error

### DIFF
--- a/src/snap/snap.js
+++ b/src/snap/snap.js
@@ -143,6 +143,10 @@
 			}
 		}
 
+		if ( i == l ) {
+			return this.currentPage;
+		}
+
 		l = this.pages[i].length;
 
 		for ( ; m < l; m++ ) {


### PR DESCRIPTION
Steps to reproduce:
- Copy the [event passthrough demo](http://lab.cubiq.org/iscroll5/demos/event-passthrough/)
- Add `snap: "li"` to config
- Change `#scroller`width to something higher, e.g. 3400 px
- Scroll to the very end and try to push the last item out of the screen
