### PR TITLE
Fixed #653.

### DIFF
--- a/src/indicator/indicator.js
+++ b/src/indicator/indicator.js
@@ -408,10 +408,10 @@ Indicator.prototype = {
 		val = val ? '1' : '0';
 
 		this.wrapperStyle[utils.style.transitionDuration] = time + 'ms';
-
-		this.fadeTimeout = setTimeout((function (val) {
-			this.wrapperStyle.opacity = val;
-			this.visible = +val;
-		}).bind(this, val), delay);
+		var $this = this;
+		this.fadeTimeout = setTimeout(function () {
+			$this.wrapperStyle.opacity = val;
+			$this.visible = +val;
+		}, delay);
 	}
 };


### PR DESCRIPTION
The original fix provided for #653 simply disabled the functionally to fade out the indicator if on Android. My fix drops the use of Function.prototype.bind in favor of a local variable. I noticed that the variable 'val' was being passed into the function via bind. I'm not sure if there is any way that the variable 'val' can change after the setTimeout call is made, but if so, the fix would be to wrap the setTimeout call into another function passing in the 'val' variable as a parameter.
