### PR TITLE
Firefox mouse wheel zooming not working

### DIFF
--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -1181,9 +1181,10 @@ IScroll.prototype = {
 			return;
 		}
 
-		deltaScale = this.scale + wheelDeltaY / 5;
-
-		this.zoom(deltaScale, e.pageX, e.pageY, 0);
+		if(wheelDeltaY) {
+			deltaScale = this.scale + wheelDeltaY / 5;
+			this.zoom(deltaScale, e.pageX, e.pageY, 0);
+		}
 	},
 
 	_initWheel: function () {

--- a/src/zoom/zoom.js
+++ b/src/zoom/zoom.js
@@ -169,7 +169,8 @@
 			return;
 		}
 
-		deltaScale = this.scale + wheelDeltaY / 5;
-
-		this.zoom(deltaScale, e.pageX, e.pageY, 0);
+		if(wheelDeltaY) {
+			deltaScale = this.scale + wheelDeltaY / 5;
+			this.zoom(deltaScale, e.pageX, e.pageY, 0);
+		}
 	},


### PR DESCRIPTION
In Firefox 29.0.1 (PC and Mac) and Firefox 30 (PC), mouse wheel zooming does not work. I was able to reproduce this using your zooming demo (http://lab.cubiq.org/iscroll5/demos/zoom/).

It looks to be a copy and paste problem, using e.wheelDelta when it is not defined. 
