### PR TITLE
build fails if ./dist folder is not existing

### DIFF
--- a/build.js
+++ b/build.js
@@ -151,5 +151,12 @@ function build (release) {
 	// Write dist file
 	var distFile = buildFile.replace('/build/', '/dist/').replace('.js', '-min.js');
 	out = uglify.minify(out, { fromString: true });
+
+	// Make sure dist folder exists
+	if ( !fs.existsSync('dist') ) {
+		fs.mkdirSync('dist');
+	}
+
+	// Write files to target
 	fs.writeFileSync(distFile, banner + out.code);
 }


### PR DESCRIPTION
The default build (no args) fails if the dist folder is not existing

env: MacOSX 10.9.1, node v0.10.25
