### PR TITLE
navigator.msPointerEnabled got deprecated

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -78,7 +78,7 @@ var utils = (function () {
 		hasTransform: _transform !== false,
 		hasPerspective: _prefixStyle('perspective') in _elementStyle,
 		hasTouch: 'ontouchstart' in window,
-		hasPointer: navigator.msPointerEnabled,
+		hasPointer: window.MSPointerEvent,
 		hasTransition: _prefixStyle('transition') in _elementStyle
 	});
 


### PR DESCRIPTION
the used flag got deprecated, the recommended way to detect MSPointerEvents are a test against window as described here:
http://msdn.microsoft.com/en-us/library/windows/apps/hh972607.aspx
