### PR TITLE
Fix the utils.prefixPointerEvent function

### DIFF
--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -49,7 +49,7 @@ var utils = (function () {
 
 	me.prefixPointerEvent = function (pointerEvent) {
 		return window.MSPointerEvent ? 
-			'MSPointer' + pointerEvent.charAt(9).toUpperCase() + pointerEvent.substr(10):
+			'MSPointer' + pointerEvent.charAt(7).toUpperCase() + pointerEvent.substr(8):
 			pointerEvent;
 	};
 


### PR DESCRIPTION
You're calculating char positions for "MSPointerDown", "MSPointerMove"... instead of "pointerdown", "pointermove" ect.
