### PR TITLE
Fix Issue #577 - Scrolling way too slow in Firefox

### DIFF
--- a/src/wheel/wheel.js
+++ b/src/wheel/wheel.js
@@ -35,8 +35,13 @@
 		}, 400);
 
 		if ( 'deltaX' in e ) {
-			wheelDeltaX = -e.deltaX;
-			wheelDeltaY = -e.deltaY;
+			if (e.deltaMode === 1) {
+				wheelDeltaX = -e.deltaX * this.options.mouseWheelSpeed;
+				wheelDeltaY = -e.deltaY * this.options.mouseWheelSpeed;
+			} else {
+				wheelDeltaX = -e.deltaX;
+				wheelDeltaY = -e.deltaY;
+			}
 		} else if ( 'wheelDeltaX' in e ) {
 			wheelDeltaX = e.wheelDeltaX / 120 * this.options.mouseWheelSpeed;
 			wheelDeltaY = e.wheelDeltaY / 120 * this.options.mouseWheelSpeed;


### PR DESCRIPTION
This ensures that scroll speed is normal (instead of painfully slow) in the latest versions of Firefox
