### PR TITLE
Android 4.4.4 is judged to be bad Android

### DIFF
--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -90,9 +90,9 @@ var utils = (function () {
 		hasTransition: _prefixStyle('transition') in _elementStyle
 	});
 
-	// This should find all Android browsers lower than build 535.19 (both stock browser and webview)
-	me.isBadAndroid = /Android /.test(window.navigator.appVersion) && !(/Chrome\/\d/.test(window.navigator.appVersion));
-
+	// This should find all Android browsers lower than build 534.30 (both stock browser and webview)
+	var _ver = window.navigator.appVersion;
+	me.isBadAndroid = /Android /.test(_ver) && ((_ver = _ver.match(/AppleWebKit\/(\d+\.\d+)/)) && _ver[1] < 534.30);
 	me.extend(me.style = {}, {
 		transform: _transform,
 		transitionTimingFunction: _prefixStyle('transitionTimingFunction'),

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,9 +88,9 @@ var utils = (function () {
 		hasTransition: _prefixStyle('transition') in _elementStyle
 	});
 
-	// This should find all Android browsers lower than build 535.19 (both stock browser and webview)
-	me.isBadAndroid = /Android /.test(window.navigator.appVersion) && !(/Chrome\/\d/.test(window.navigator.appVersion));
-
+	// This should find all Android browsers lower than build 534.30 (both stock browser and webview)
+	var _ver = window.navigator.appVersion;
+	me.isBadAndroid = /Android /.test(_ver) && ((_ver = _ver.match(/AppleWebKit\/(\d+\.\d+)/)) && _ver[1] < 534.30);
 	me.extend(me.style = {}, {
 		transform: _transform,
 		transitionTimingFunction: _prefixStyle('transitionTimingFunction'),


### PR DESCRIPTION
Below this judgment, it seems android 4.4.4 is also considered bad android

``` js
// This should find all Android browsers lower than build 535.19 (both stock browser and webview)
me.isBadAndroid = /Android /.test(window.navigator.appVersion) && !(/Chrome\/\d/.test(window.navigator.appVersion));
```

Here is the userAgent string in default browser

```
5.0 (Linux; U; Android 4.4.4; zh-cn; M353 Build/KTU84P)
AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
```

Here is the userAgent string in webview

```
5.0 (Linux; Android 4.4.4; M353 Build/KTU84P)
AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0
Mobile Safari/537.36 
```

See: http://jimbergman.net/webkit-version-in-android-version/
