### PR TITLE
Allow page scrolling ( wheel ) when scroll reaches top and/or bottom, and when there is nothing to scroll ( wheel, touch )

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -113,7 +113,7 @@ IScroll.prototype = {
 			return;
 		}
 
-		if ( this.options.preventDefault && !utils.isBadAndroid && !utils.preventDefaultException(e.target, this.options.preventDefaultException) ) {
+		if ( this.options.preventDefault && !utils.isBadAndroid && !utils.preventDefaultException(e.target, this.options.preventDefaultException) && this.maxScroll > 0 ) {
 			e.preventDefault();
 		}
 
@@ -155,10 +155,6 @@ IScroll.prototype = {
 	_move: function (e) {
 		if ( !this.enabled || utils.eventType[e.type] !== this.initiated ) {
 			return;
-		}
-
-		if ( this.options.preventDefault ) {	// increases performance on Android? TODO: check!
-			e.preventDefault();
 		}
 
 		var point		= e.touches ? e.touches[0] : e,
@@ -224,6 +220,10 @@ IScroll.prototype = {
 		}
 		if ( newY > 0 || newY < this.maxScrollY ) {
 			newY = this.options.bounce ? this.y + deltaY / 3 : newY > 0 ? 0 : this.maxScrollY;
+		}
+
+		if ( this.options.preventDefault && newY > 0 && newY < this.maxScrollY ) {	// increases performance on Android? TODO: check!
+			e.preventDefault();
 		}
 
 		this.directionX = deltaX > 0 ? -1 : deltaX < 0 ? 1 : 0;

--- a/src/wheel/wheel.js
+++ b/src/wheel/wheel.js
@@ -91,7 +91,7 @@
 			newY = this.maxScrollY;
 		}
 
-		if( newY !== 0 && newY !== this.maxScrollY){
+		if( newY > 0 && newY < this.maxScrollY){
 			e.preventDefault();
 		}
 


### PR DESCRIPTION
This is useful when the text is dynamic and you want to reuse the same container without doing a check and creating/destroying the iScroll object.
- Ability to scroll ( touch, wheel ) when there is nothing to scroll. 
- Recreated the native scroll ability to scroll the page once the scroll reaches to the top and/or bottom.
