### PR TITLE
Fix scrollEnd event from double firing

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -97,7 +97,9 @@ IScroll.prototype = {
 		this._transitionTime();
 		if ( !this.resetPosition(this.options.bounceTime) ) {
 			this.isInTransition = false;
-			this._execEvent('scrollEnd');
+			if (this.wheelTimeout === undefined) {
+				this._execEvent('scrollEnd');
+			}
 		}
 	},
 


### PR DESCRIPTION
https://github.com/cubiq/iscroll/issues/761

On wheelscroll the scrollEnd event was firing twice. Once from _transitionEnd (core.js) and once from a timeout in _wheel (wheel.js).

Placed a check in _transitionEnd to only fire scrollEnd event if _wheel's scrollEnd event is already set to execute.
