### PR TITLE
Passthrough for wheel

### DIFF
--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -1072,6 +1072,12 @@ IScroll.prototype = {
 			return;
 		}
 
+		// pass through
+		var direction = Math.abs(wheelDeltaX) >= Math.abs(wheelDeltaY) ? 'horizontal' : 'vertical';
+		if (direction === this.options.eventPassthrough) {
+			return;
+		}
+
 		wheelDeltaX *= this.options.invertWheelDirection;
 		wheelDeltaY *= this.options.invertWheelDirection;
 

--- a/src/wheel/wheel.js
+++ b/src/wheel/wheel.js
@@ -53,6 +53,12 @@
 			return;
 		}
 
+		// pass through
+		var direction = Math.abs(wheelDeltaX) >= Math.abs(wheelDeltaY) ? 'horizontal' : 'vertical';
+		if (direction === this.options.eventPassthrough) {
+			return;
+		}
+
 		wheelDeltaX *= this.options.invertWheelDirection;
 		wheelDeltaY *= this.options.invertWheelDirection;
 


### PR DESCRIPTION
consider passthrough on wheel event to enable navigation on nested elements. E.g. one vertical list (`scrollY: true`, `scrollX:false`) with multiple nested horizontal lists (`scrollY: false`, `scrollX:true`)
