### PR TITLE
Release parent scrolling when there is nothing left to scroll

### DIFF
--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -1035,7 +1035,6 @@ IScroll.prototype = {
 			return;
 		}
 
-		e.preventDefault();
 		e.stopPropagation();
 
 		var wheelDeltaX, wheelDeltaY,
@@ -1103,6 +1102,16 @@ IScroll.prototype = {
 
 		newX = this.x + Math.round(this.hasHorizontalScroll ? wheelDeltaX : 0);
 		newY = this.y + Math.round(this.hasVerticalScroll ? wheelDeltaY : 0);
+
+		if (
+			!this.options.releaseScroll ||
+			(
+				(this.hasVerticalScroll && newY < 0 && newY > this.maxScrollY) ||
+				(this.hasHorizontalScroll && newX < 0 && newX > this.maxScrollX)
+			)
+		) {
+			e.preventDefault();
+		}
 
 		if ( newX > 0 ) {
 			newX = 0;

--- a/src/wheel/wheel.js
+++ b/src/wheel/wheel.js
@@ -16,7 +16,6 @@
 			return;
 		}
 
-		e.preventDefault();
 		e.stopPropagation();
 
 		var wheelDeltaX, wheelDeltaY,
@@ -84,6 +83,16 @@
 
 		newX = this.x + Math.round(this.hasHorizontalScroll ? wheelDeltaX : 0);
 		newY = this.y + Math.round(this.hasVerticalScroll ? wheelDeltaY : 0);
+
+		if (
+			!this.options.releaseScroll ||
+			(
+				(this.hasVerticalScroll && newY < 0 && newY > this.maxScrollY) ||
+				(this.hasHorizontalScroll && newX < 0 && newX > this.maxScrollX)
+			)
+		) {
+			e.preventDefault();
+		}
 
 		if ( newX > 0 ) {
 			newX = 0;


### PR DESCRIPTION
Only applies to wheel events, but the logic should mostly be the same for touch and mouse. See also #786 for an alternate solution.
#701
