### PR TITLE
Relative momentum

### DIFF
--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -1543,10 +1543,23 @@ IScroll.prototype = {
             destY += offsetX;
           }
 
+          offsetY = that.y - lastY;
+          offsetX = that.x - lastX;
+
+          if (offsetX) {
+            startX += offsetX;
+            destX += offsetX;
+          }
+
+          if (offsetY) {
+            startY += offsetY;
+            destY += offsetY;
+          }
+
 			now = ( now - startTime ) / duration;
 			easing = easingFn(now);
-			newX = ( destX - startX ) * easing + startX;
-			newY = ( destY - startY ) * easing + startY;
+			newX = lastX = ( destX - startX ) * easing + startX;
+			newY = lastY = ( destY - startY ) * easing + startY;
 			that._translate(newX, newY);
 
 			if ( that.isAnimating ) {

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -1539,8 +1539,8 @@ IScroll.prototype = {
           }
 
           if (offsetY) {
-            startY += offsetX;
-            destY += offsetX;
+            startY += offsetY;
+            destY += offsetY;
           }
 
           offsetY = that.y - lastY;

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -1508,12 +1508,15 @@ IScroll.prototype = {
 		var that = this,
 			startX = this.x,
 			startY = this.y,
+          lastX = startX,
+          lastY = startY,
 			startTime = utils.getTime(),
 			destTime = startTime + duration;
 
 		function step () {
 			var now = utils.getTime(),
 				newX, newY,
+             offsetX, offsetY,
 				easing;
 
 			if ( now >= destTime ) {
@@ -1526,6 +1529,19 @@ IScroll.prototype = {
 
 				return;
 			}
+      
+          offsetY = that.y - lastY;
+          offsetX = that.x - lastX;
+
+          if (offsetX) {
+            startX += offsetX;
+            destX += offsetX;
+          }
+
+          if (offsetY) {
+            startY += offsetX;
+            destY += offsetX;
+          }
 
 			now = ( now - startTime ) / duration;
 			easing = easingFn(now);

--- a/src/probe/_animate.js
+++ b/src/probe/_animate.js
@@ -34,8 +34,8 @@
           }
 
           if (offsetY) {
-            startY += offsetX;
-            destY += offsetX;
+            startY += offsetY;
+            destY += offsetY;
           }
 
           offsetY = that.y - lastY;

--- a/src/probe/_animate.js
+++ b/src/probe/_animate.js
@@ -3,12 +3,15 @@
 		var that = this,
 			startX = this.x,
 			startY = this.y,
+          lastX = startX,
+          lastY = startY,
 			startTime = utils.getTime(),
 			destTime = startTime + duration;
 
 		function step () {
 			var now = utils.getTime(),
 				newX, newY,
+             offsetX, offsetY,
 				easing;
 
 			if ( now >= destTime ) {
@@ -22,10 +25,23 @@
 				return;
 			}
 
+          offsetY = that.y - lastY;
+          offsetX = that.x - lastX;
+
+          if (offsetX) {
+            startX += offsetX;
+            destX += offsetX;
+          }
+
+          if (offsetY) {
+            startY += offsetY;
+            destY += offsetY;
+          }
+
 			now = ( now - startTime ) / duration;
 			easing = easingFn(now);
-			newX = ( destX - startX ) * easing + startX;
-			newY = ( destY - startY ) * easing + startY;
+			newX = lastX = ( destX - startX ) * easing + startX;
+			newY = lastY = ( destY - startY ) * easing + startY;
 			that._translate(newX, newY);
 
 			if ( that.isAnimating ) {


### PR DESCRIPTION
Allows the use of methods like `scrollBy` or `scrollTo` while momentum get's animated.

Without the changes in this pull request the the new X/Y values set by the methods mentioned above will simply be ignored.