### PR TITLE
Press event

### DIFF
--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -218,7 +218,7 @@ var utils = (function () {
 		}
 	});
 
-	me.tap = function (e, eventName) {
+	me.tap = me.press = function (e, eventName) {
 		var ev = document.createEvent('Event');
 		ev.initEvent(eventName, true, true);
 		ev.pageX = e.pageX;
@@ -307,6 +307,10 @@ function IScroll (el, options) {
 	if ( this.options.tap === true ) {
 		this.options.tap = 'tap';
 	}
+
+    if ( this.options.press === true ) {
+      this.options.press = 'press';
+    }
 
 	this.options.invertWheelDirection = this.options.invertWheelDirection ? -1 : 1;
 
@@ -567,9 +571,13 @@ IScroll.prototype = {
 
 		// we scrolled less than 10 pixels
 		if ( !this.moved ) {
-			if ( this.options.tap ) {
+			if ( this.options.tap && duration < 500) {
 				utils.tap(e, this.options.tap);
 			}
+
+          if ( this.options.press && duration >= 500) {
+            utils.press(e, this.options.press);
+          }
 
 			if ( this.options.click ) {
 				utils.click(e);

--- a/build/iscroll-lite.js
+++ b/build/iscroll-lite.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -218,7 +218,7 @@ var utils = (function () {
 		}
 	});
 
-	me.tap = function (e, eventName) {
+	me.tap = me.press = function (e, eventName) {
 		var ev = document.createEvent('Event');
 		ev.initEvent(eventName, true, true);
 		ev.pageX = e.pageX;
@@ -300,6 +300,10 @@ function IScroll (el, options) {
 	if ( this.options.tap === true ) {
 		this.options.tap = 'tap';
 	}
+
+    if ( this.options.press === true ) {
+      this.options.press = 'press';
+    }
 
 // INSERT POINT: NORMALIZATION
 
@@ -528,9 +532,13 @@ IScroll.prototype = {
 
 		// we scrolled less than 10 pixels
 		if ( !this.moved ) {
-			if ( this.options.tap ) {
+			if ( this.options.tap && duration < 500) {
 				utils.tap(e, this.options.tap);
 			}
+
+          if ( this.options.press && duration >= 500) {
+            utils.press(e, this.options.press);
+          }
 
 			if ( this.options.click ) {
 				utils.click(e);

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -218,7 +218,7 @@ var utils = (function () {
 		}
 	});
 
-	me.tap = function (e, eventName) {
+	me.tap = me.press = function (e, eventName) {
 		var ev = document.createEvent('Event');
 		ev.initEvent(eventName, true, true);
 		ev.pageX = e.pageX;
@@ -306,6 +306,10 @@ function IScroll (el, options) {
 	if ( this.options.tap === true ) {
 		this.options.tap = 'tap';
 	}
+
+    if ( this.options.press === true ) {
+      this.options.press = 'press';
+    }
 
 	if ( this.options.shrinkScrollbars == 'scale' ) {
 		this.options.useTransition = false;
@@ -565,9 +569,13 @@ IScroll.prototype = {
 
 		// we scrolled less than 10 pixels
 		if ( !this.moved ) {
-			if ( this.options.tap ) {
+			if ( this.options.tap && duration < 500) {
 				utils.tap(e, this.options.tap);
 			}
+
+          if ( this.options.press && duration >= 500) {
+            utils.press(e, this.options.press);
+          }
 
 			if ( this.options.click ) {
 				utils.click(e);

--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -218,7 +218,7 @@ var utils = (function () {
 		}
 	});
 
-	me.tap = function (e, eventName) {
+	me.tap = me.press = function (e, eventName) {
 		var ev = document.createEvent('Event');
 		ev.initEvent(eventName, true, true);
 		ev.pageX = e.pageX;
@@ -309,6 +309,10 @@ function IScroll (el, options) {
 	if ( this.options.tap === true ) {
 		this.options.tap = 'tap';
 	}
+
+    if ( this.options.press === true ) {
+      this.options.press = 'press';
+    }
 
 	if ( this.options.shrinkScrollbars == 'scale' ) {
 		this.options.useTransition = false;
@@ -565,9 +569,13 @@ IScroll.prototype = {
 
 		// we scrolled less than 10 pixels
 		if ( !this.moved ) {
-			if ( this.options.tap ) {
+			if ( this.options.tap && duration < 500) {
 				utils.tap(e, this.options.tap);
 			}
+
+          if ( this.options.press && duration >= 500) {
+            utils.press(e, this.options.press);
+          }
 
 			if ( this.options.click ) {
 				utils.click(e);

--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -218,7 +218,7 @@ var utils = (function () {
 		}
 	});
 
-	me.tap = function (e, eventName) {
+	me.tap = me.press = function (e, eventName) {
 		var ev = document.createEvent('Event');
 		ev.initEvent(eventName, true, true);
 		ev.pageX = e.pageX;
@@ -306,6 +306,10 @@ function IScroll (el, options) {
 	if ( this.options.tap === true ) {
 		this.options.tap = 'tap';
 	}
+
+    if ( this.options.press === true ) {
+      this.options.press = 'press';
+    }
 
 	if ( this.options.shrinkScrollbars == 'scale' ) {
 		this.options.useTransition = false;
@@ -556,9 +560,13 @@ IScroll.prototype = {
 
 		// we scrolled less than 10 pixels
 		if ( !this.moved ) {
-			if ( this.options.tap ) {
+			if ( this.options.tap && duration < 500) {
 				utils.tap(e, this.options.tap);
 			}
+
+          if ( this.options.press && duration >= 500) {
+            utils.press(e, this.options.press);
+          }
 
 			if ( this.options.click ) {
 				utils.click(e);

--- a/src/core.js
+++ b/src/core.js
@@ -55,6 +55,10 @@ function IScroll (el, options) {
 		this.options.tap = 'tap';
 	}
 
+    if ( this.options.press === true ) {
+      this.options.press = 'press';
+    }
+
 // INSERT POINT: NORMALIZATION
 
 	// Some defaults	
@@ -282,9 +286,13 @@ IScroll.prototype = {
 
 		// we scrolled less than 10 pixels
 		if ( !this.moved ) {
-			if ( this.options.tap ) {
+			if ( this.options.tap && duration < 500) {
 				utils.tap(e, this.options.tap);
 			}
+
+          if ( this.options.press && duration >= 500) {
+            utils.press(e, this.options.press);
+          }
 
 			if ( this.options.click ) {
 				utils.click(e);

--- a/src/utils.js
+++ b/src/utils.js
@@ -216,7 +216,7 @@ var utils = (function () {
 		}
 	});
 
-	me.tap = function (e, eventName) {
+	me.tap = me.press = function (e, eventName) {
 		var ev = document.createEvent('Event');
 		ev.initEvent(eventName, true, true);
 		ev.pageX = e.pageX;


### PR DESCRIPTION
This pull request adds a `press` event.
The existing `tap` event will only be triggered when the tap duration is lower than 500ms, otherwise an `press` event will be fired.

This makes it possible to use iscroll `tap` events in conjunction with libraries like hammer.js, which make a distinction between `tap` and `press`.