### PR TITLE
Update utils.js - there is a bug

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,7 @@ var utils = (function () {
 
 	me.prefixPointerEvent = function (pointerEvent) {
 		return window.MSPointerEvent ? 
-			'MSPointer' + pointerEvent.charAt(9).toUpperCase() + pointerEvent.substr(10):
+			'MSPointer' + pointerEvent.charAt(7).toUpperCase() + pointerEvent.substr(8):
 			pointerEvent;
 	};
 


### PR DESCRIPTION
'MSPointer' + pointerEvent.charAt(9).toUpperCase() + pointerEvent.substr(10):
should be
'MSPointer' + pointerEvent.charAt(7).toUpperCase() + pointerEvent.substr(8):