### PR TITLE
Support a scrollbar background element

### DIFF
--- a/src/indicator/indicator.js
+++ b/src/indicator/indicator.js
@@ -243,11 +243,11 @@ Indicator.prototype = {
 		this.transitionTime();
 
 		if ( this.options.listenX && !this.options.listenY ) {
-			this.indicatorStyle.display = this.scroller.hasHorizontalScroll ? 'block' : 'none';
+			this.wrapperStyle.display = this.scroller.hasHorizontalScroll ? 'block' : 'none';
 		} else if ( this.options.listenY && !this.options.listenX ) {
-			this.indicatorStyle.display = this.scroller.hasVerticalScroll ? 'block' : 'none';
+			this.wrapperStyle.display = this.scroller.hasVerticalScroll ? 'block' : 'none';
 		} else {
-			this.indicatorStyle.display = this.scroller.hasHorizontalScroll || this.scroller.hasVerticalScroll ? 'block' : 'none';
+			this.wrapperStyle.display = this.scroller.hasHorizontalScroll || this.scroller.hasVerticalScroll ? 'block' : 'none';
 		}
 
 		if ( this.scroller.hasHorizontalScroll && this.scroller.hasVerticalScroll ) {


### PR DESCRIPTION
This pull request is basically an improvement.

I've styled a scrollbar lately and if I style it so it has a background, only the indicator disappears when there's not enough elements to overflow.

For now, I don't think there's a point to improve the code and add a custom template system.
I've just hid the wrapper element.