### PR TITLE
Fix for carousel on iOS8 devices

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -330,7 +330,9 @@ IScroll.prototype = {
 		clearTimeout(this.resizeTimeout);
 
 		this.resizeTimeout = setTimeout(function () {
-			that.refresh();
+			if ( this.options.resizeIgnore === undefined && !this.options.resizeIgnore ) {
+				that.refresh();
+			}
 		}, this.options.resizePolling);
 	},
 


### PR DESCRIPTION
Proposed this.options.resizeIgnore which can be set by user as resizeIgnore = true to prevent resize event initiated restart of carousel. The reason for it is browser in iOS8 which sometimes fires up resize event by up/down swipe.