### PR TITLE
Tweak infinity scrolling

### DIFF
--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -48,7 +48,7 @@ var utils = (function () {
 	};
 
 	me.prefixPointerEvent = function (pointerEvent) {
-		return window.MSPointerEvent ? 
+		return window.MSPointerEvent ?
 			'MSPointer' + pointerEvent.charAt(9).toUpperCase() + pointerEvent.substr(10):
 			pointerEvent;
 	};
@@ -259,7 +259,7 @@ function IScroll (el, options) {
 		infiniteUseTransform: true,
 		deceleration: 0.004,
 
-// INSERT POINT: OPTIONS 
+// INSERT POINT: OPTIONS
 
 		startX: 0,
 		startY: 0,
@@ -320,7 +320,7 @@ function IScroll (el, options) {
 
 // INSERT POINT: NORMALIZATION
 
-	// Some defaults	
+	// Some defaults
 	this.x = 0;
 	this.y = 0;
 	this.directionX = 0;
@@ -682,7 +682,7 @@ IScroll.prototype = {
 		this.scrollerHeight	= this.scroller.offsetHeight;
 
 		this.maxScrollX		= this.wrapperWidth - this.scrollerWidth;
-		
+
 		var limit;
 		if ( this.options.infiniteElements ) {
 			this.options.infiniteLimit = this.options.infiniteLimit || Math.floor(2147483645 / this.infiniteElementHeight);
@@ -1397,7 +1397,7 @@ IScroll.prototype = {
 			if ( now >= destTime ) {
 				that.isAnimating = false;
 				that._translate(destX, destY);
-				
+
 				if ( !that.resetPosition(that.options.bounceTime) ) {
 					that._execEvent('scrollEnd');
 				}
@@ -1432,12 +1432,16 @@ IScroll.prototype = {
 		this.infiniteMaster = this.infiniteElements[0];
 		this.infiniteElementHeight = this.infiniteMaster.offsetHeight;
 		this.infiniteHeight = this.infiniteLength * this.infiniteElementHeight;
+		// Used to check if we are currently loading any data.
+		this.dataLoads = [];
+		// Used to check if a fixed row limit was set in the options. If not, a limit
+		// is set when the end of the cache is reached and no more data is loading.
+		this.infiniteLimitSet = this.options.infiniteLimit !== undefined;
 
 		this.options.cacheSize = this.options.cacheSize || 1000;
 		this.infiniteCacheBuffer = Math.round(this.options.cacheSize / 4);
 
-		//this.infiniteCache = {};
-		this.options.dataset.call(this, 0, this.options.cacheSize);
+		this.loadData(0, this.options.cacheSize);
 
 		this.on('refresh', function () {
 			var elementsPerPage = Math.ceil(this.wrapperHeight / this.infiniteElementHeight);
@@ -1450,8 +1454,6 @@ IScroll.prototype = {
 
 	// TO-DO: clean up the mess
 	reorderInfinite: function () {
-		var center = -this.y + this.wrapperHeight / 2;
-
 		var minorPhase = Math.max(Math.floor(-this.y / this.infiniteElementHeight) - this.infiniteUpperBufferSize, 0),
 			majorPhase = Math.floor(minorPhase / this.infiniteLength),
 			phase = minorPhase - majorPhase * this.infiniteLength;
@@ -1488,7 +1490,7 @@ IScroll.prototype = {
 		}
 
 		if ( this.cachePhase != cachePhase && (cachePhase === 0 || minorPhase - this.infiniteCacheBuffer > 0) ) {
-			this.options.dataset.call(this, Math.max(cachePhase * this.infiniteCacheBuffer - this.infiniteCacheBuffer, 0), this.options.cacheSize);
+			this.loadData(Math.max(cachePhase * this.infiniteCacheBuffer - this.infiniteCacheBuffer, 0), this.options.cacheSize);
 		}
 
 		this.cachePhase = cachePhase;
@@ -1498,16 +1500,46 @@ IScroll.prototype = {
 
 	updateContent: function (els) {
 		if ( this.infiniteCache === undefined ) {
+			// We need to disable scrolling and updating until we have data!
+			this.disable();
 			return;
 		}
 
 		for ( var i = 0, l = els.length; i < l; i++ ) {
+			// Check if the cache has data for the current element.
+			if(this.infiniteCache[els[i]._phase] === undefined) {
+				// The cache has no data for the current element. This either means
+				// the data is still loading or there is no more data.
+				if(this.dataLoads.length > 0) {
+					// Still loading data...
+					this.disable();
+					this.infiniteCacheUpdateAfterLoad = true;
+					return;
+				} else {
+					// Not loading any more data. End of data reached. Clear row and set row limit.
+					els[i].innerHTML = '';
+					if(!this.infiniteLimitSet) {
+						this.infiniteLimitSet = true;
+						// Calculation of new row limit is pretty much the same as in *refresh* method.
+						this.options.infiniteLimit = Math.floor(els[i]._top / this.infiniteElementHeight);
+						this.maxScrollY = -this.options.infiniteLimit * this.infiniteElementHeight + this.wrapperHeight;
+					}
+					return;
+				}
+			}
 			this.options.dataFiller.call(this, els[i], this.infiniteCache[els[i]._phase]);
 		}
 	},
 
+	loadData: function(start, count) {
+		this.dataLoads.push(1);
+		this.options.dataset.call(this, start, count);
+	},
+
 	updateCache: function (start, data) {
 		var firstRun = this.infiniteCache === undefined;
+		var updateAfterLoad = this.infiniteCacheUpdateAfterLoad !== undefined;
+		this.infiniteCacheUpdateAfterLoad = undefined;
 
 		this.infiniteCache = {};
 
@@ -1515,10 +1547,13 @@ IScroll.prototype = {
 			this.infiniteCache[start++] = data[i];
 		}
 
+		this.dataLoads.pop();
+
 		if ( firstRun ) {
 			this.updateContent(this.infiniteElements);
 		}
 
+		this.enable();
 	},
 
 

--- a/demos/infinite/index.html
+++ b/demos/infinite/index.html
@@ -62,9 +62,13 @@ function loaded () {
 	myScroll = new IScroll('#wrapper', {
 		mouseWheel: true,
 		infiniteElements: '#scroller .row',
+		// You can set a fixed row limit here. If you don't, the limit is reached
+		// when no further data is available for scrolling.
 		//infiniteLimit: 2000,
 		dataset: requestData,
 		dataFiller: updateContent,
+		// Remember: This should be at least 4 times the number of fixed rows
+		// (aka li elements) in your scroller.
 		cacheSize: 1000
 	});
 }
@@ -73,7 +77,8 @@ function requestData (start, count) {
 	ajax('dataset.php?start=' + +start + '&count=' + +count, {
 		callback: function (data) {
 			data = JSON.parse(data);
-			myScroll.updateCache(start, data);
+			// Remember: The server must return an empty array if no further data is available!
+			if(data.length > 0) myScroll.updateCache(start, data);
 		}
 	});
 }


### PR DESCRIPTION
I found two quirks in infinity scrolling I tried to address with this pull request:

1.) The scroller didn't stop updating elements while data was still loading from the server. This results in previous elements reappearing again in the scroller. I fixed that by checking if data for a element (aka phase) is available in the cache. If not disable scrolling until data becomes available.

2.) The scroller doesn't stop when end of data is reached and is scrolling the last couple of elements over and over. The fix is pretty much the same like the fix above with additionally checking if we are still loading data. You have the *infiniteLimit* as an option. This basically is not necessary anymore now because it can be set automatically when the dataset method does not return any more data.