### PR TITLE
Tweak infinity scrolling

### DIFF
--- a/demos/infinite/index.html
+++ b/demos/infinite/index.html
@@ -62,9 +62,13 @@ function loaded () {
 	myScroll = new IScroll('#wrapper', {
 		mouseWheel: true,
 		infiniteElements: '#scroller .row',
+		// You can set a fixed row limit here. If you don't, the limit is reached
+		// when no further data is available for scrolling.
 		//infiniteLimit: 2000,
 		dataset: requestData,
 		dataFiller: updateContent,
+		// Remember: This should be at least 4 times the number of fixed rows
+		// (aka li elements) in your scroller.
 		cacheSize: 1000
 	});
 }
@@ -73,7 +77,8 @@ function requestData (start, count) {
 	ajax('dataset.php?start=' + +start + '&count=' + +count, {
 		callback: function (data) {
 			data = JSON.parse(data);
-			myScroll.updateCache(start, data);
+			// Remember: The server must return an empty array if no further data is available!
+			if(data.length > 0) myScroll.updateCache(start, data);
 		}
 	});
 }

--- a/src/infinite/infinite.js
+++ b/src/infinite/infinite.js
@@ -7,12 +7,16 @@
 		this.infiniteMaster = this.infiniteElements[0];
 		this.infiniteElementHeight = this.infiniteMaster.offsetHeight;
 		this.infiniteHeight = this.infiniteLength * this.infiniteElementHeight;
+		// Used to check if we are currently loading any data.
+		this.dataLoads = [];
+		// Used to check if a fixed row limit was set in the options. If not, a limit
+		// is set when the end of the cache is reached and no more data is loading.
+		this.infiniteLimitSet = this.options.infiniteLimit !== undefined;
 
 		this.options.cacheSize = this.options.cacheSize || 1000;
 		this.infiniteCacheBuffer = Math.round(this.options.cacheSize / 4);
 
-		//this.infiniteCache = {};
-		this.options.dataset.call(this, 0, this.options.cacheSize);
+		this.loadData(0, this.options.cacheSize);
 
 		this.on('refresh', function () {
 			var elementsPerPage = Math.ceil(this.wrapperHeight / this.infiniteElementHeight);
@@ -63,7 +67,7 @@
 		}
 
 		if ( this.cachePhase != cachePhase && (cachePhase === 0 || minorPhase - this.infiniteCacheBuffer > 0) ) {
-			this.options.dataset.call(this, Math.max(cachePhase * this.infiniteCacheBuffer - this.infiniteCacheBuffer, 0), this.options.cacheSize);
+			this.loadData(Math.max(cachePhase * this.infiniteCacheBuffer - this.infiniteCacheBuffer, 0), this.options.cacheSize);
 		}
 
 		this.cachePhase = cachePhase;
@@ -73,16 +77,46 @@
 
 	updateContent: function (els) {
 		if ( this.infiniteCache === undefined ) {
+			// We need to disable scrolling and updating until we have data!
+			this.disable();
 			return;
 		}
 
 		for ( var i = 0, l = els.length; i < l; i++ ) {
+			// Check if the cache has data for the current element.
+			if(this.infiniteCache[els[i]._phase] === undefined) {
+				// The cache has no data for the current element. This either means
+				// the data is still loading or there is no more data.
+				if(this.dataLoads.length > 0) {
+					// Still loading data...
+					this.disable();
+					this.infiniteCacheUpdateAfterLoad = true;
+					return;
+				} else {
+					// Not loading any more data. End of data reached. Clear row and set row limit.
+					els[i].innerHTML = '';
+					if(!this.infiniteLimitSet) {
+						this.infiniteLimitSet = true;
+						// Calculation of new row limit is pretty much the same as in *refresh* method.
+						this.options.infiniteLimit = Math.floor(els[i]._top / this.infiniteElementHeight);
+						this.maxScrollY = -this.options.infiniteLimit * this.infiniteElementHeight + this.wrapperHeight;
+					}
+					return;
+				}
+			}
 			this.options.dataFiller.call(this, els[i], this.infiniteCache[els[i]._phase]);
 		}
 	},
 
+	loadData: function(start, count) {
+		this.dataLoads.push(1);
+		this.options.dataset.call(this, start, count);
+	},
+
 	updateCache: function (start, data) {
 		var firstRun = this.infiniteCache === undefined;
+		var updateAfterLoad = this.infiniteCacheUpdateAfterLoad !== undefined;
+		this.infiniteCacheUpdateAfterLoad = undefined;
 
 		this.infiniteCache = {};
 
@@ -90,9 +124,12 @@
 			this.infiniteCache[start++] = data[i];
 		}
 
+		this.dataLoads.pop();
+
 		if ( firstRun ) {
 			this.updateContent(this.infiniteElements);
 		}
 
+		this.enable();
 	},
 


### PR DESCRIPTION
I found two quirks in infinity scrolling I tried to address with this pull request:

1.) The scroller didn't stop updating elements while data was still loading from the server. This results in previous elements reappearing again in the scroller. I fixed that by checking if data for a element (aka phase) is available in the cache. If not disable scrolling until data becomes available.

2.) The scroller doesn't stop when end of data is reached and is scrolling the last couple of elements over and over. The fix is pretty much the same like the fix above with additionally checking if we are still loading data. You have the infiniteLimit as an option. This basically is not necessary anymore now because it can be set automatically when the dataset method does not return any more data.
