### PR TITLE
do my bset to make the iscroll work in the IE 6,7,8

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -536,6 +536,13 @@ IScroll.prototype = {
 			y = Math.round(y);
 			this.scrollerStyle.left = x + 'px';
 			this.scrollerStyle.top = y + 'px';
+
+			/**
+			 * if not support transform
+			 * if we want the scroller move by set left and top
+			 * the scroller should be position absolute
+			 */
+			this.scrollerStyle.position = 'absolute';
 		}
 
 		this.x = x;

--- a/src/core.js
+++ b/src/core.js
@@ -6,7 +6,7 @@ function IScroll (el, options) {
 
 	this.options = {
 
-// INSERT POINT: OPTIONS 
+// INSERT POINT: OPTIONS
 
 		startX: 0,
 		startY: 0,
@@ -57,7 +57,7 @@ function IScroll (el, options) {
 
 // INSERT POINT: NORMALIZATION
 
-	// Some defaults	
+	// Some defaults
 	this.x = 0;
 	this.y = 0;
 	this.directionX = 0;
@@ -114,7 +114,7 @@ IScroll.prototype = {
 		}
 
 		if ( this.options.preventDefault && !utils.isBadAndroid && !utils.preventDefaultException(e.target, this.options.preventDefaultException) ) {
-			e.preventDefault();
+			utils.preventDefault(e);
 		}
 
 		var point = e.touches ? e.touches[0] : e,
@@ -158,7 +158,7 @@ IScroll.prototype = {
 		}
 
 		if ( this.options.preventDefault ) {	// increases performance on Android? TODO: check!
-			e.preventDefault();
+			utils.preventDefault(e);
 		}
 
 		var point		= e.touches ? e.touches[0] : e,
@@ -194,7 +194,7 @@ IScroll.prototype = {
 
 		if ( this.directionLocked == 'h' ) {
 			if ( this.options.eventPassthrough == 'vertical' ) {
-				e.preventDefault();
+				utils.preventDefault(e);
 			} else if ( this.options.eventPassthrough == 'horizontal' ) {
 				this.initiated = false;
 				return;
@@ -203,7 +203,7 @@ IScroll.prototype = {
 			deltaY = 0;
 		} else if ( this.directionLocked == 'v' ) {
 			if ( this.options.eventPassthrough == 'horizontal' ) {
-				e.preventDefault();
+				utils.preventDefault(e);
 			} else if ( this.options.eventPassthrough == 'vertical' ) {
 				this.initiated = false;
 				return;
@@ -255,7 +255,7 @@ IScroll.prototype = {
 		}
 
 		if ( this.options.preventDefault && !utils.preventDefaultException(e.target, this.options.preventDefaultException) ) {
-			e.preventDefault();
+			utils.preventDefault(e);
 		}
 
 		var point = e.changedTouches ? e.changedTouches[0] : e,

--- a/src/default/handleEvent.js
+++ b/src/default/handleEvent.js
@@ -43,8 +43,8 @@
 				break;
 			case 'click':
 				if ( !e._constructed ) {
-					e.preventDefault();
-					e.stopPropagation();
+					utils.preventDefault(e);
+					utils.stopPropagation(e);
 				}
 				break;
 		}

--- a/src/default/handleEvent.js
+++ b/src/default/handleEvent.js
@@ -1,5 +1,6 @@
 
 	handleEvent: function (e) {
+		e = e || window.event;
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'pointerdown':

--- a/src/indicator/indicator.js
+++ b/src/indicator/indicator.js
@@ -136,8 +136,8 @@ Indicator.prototype = {
 	_start: function (e) {
 		var point = e.touches ? e.touches[0] : e;
 
-		e.preventDefault();
-		e.stopPropagation();
+		utils.preventDefault(e);
+		utils.stopPropagation(e);
 
 		this.transitionTime();
 
@@ -186,8 +186,8 @@ Indicator.prototype = {
 
 // INSERT POINT: indicator._move
 
-		e.preventDefault();
-		e.stopPropagation();
+		utils.preventDefault(e);
+		utils.stopPropagation(e);
 	},
 
 	_end: function (e) {
@@ -197,8 +197,8 @@ Indicator.prototype = {
 
 		this.initiated = false;
 
-		e.preventDefault();
-		e.stopPropagation();
+		utils.preventDefault(e);
+		utils.stopPropagation(e);
 
 		utils.removeEvent(window, 'touchmove', this);
 		utils.removeEvent(window, utils.prefixPointerEvent('pointermove'), this);
@@ -295,7 +295,7 @@ Indicator.prototype = {
 				this.maxBoundaryX = this.maxPosX;
 			}
 
-			this.sizeRatioX = this.options.speedRatioX || (this.scroller.maxScrollX && (this.maxPosX / this.scroller.maxScrollX));	
+			this.sizeRatioX = this.options.speedRatioX || (this.scroller.maxScrollX && (this.maxPosX / this.scroller.maxScrollX));
 		}
 
 		if ( this.options.listenY ) {

--- a/src/indicator/indicator.js
+++ b/src/indicator/indicator.js
@@ -87,6 +87,8 @@ function Indicator (scroller, options) {
 
 Indicator.prototype = {
 	handleEvent: function (e) {
+		e = e || window.event;
+
 		switch ( e.type ) {
 			case 'touchstart':
 			case 'pointerdown':

--- a/src/indicator/indicator.js
+++ b/src/indicator/indicator.js
@@ -5,7 +5,7 @@ function createDefaultScrollbar (direction, interactive, type) {
 
 	if ( type === true ) {
 		scrollbar.style.cssText = 'position:absolute;z-index:9999';
-		indicator.style.cssText = '-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;position:absolute;background:rgba(0,0,0,0.5);border:1px solid rgba(255,255,255,0.9);border-radius:3px';
+		indicator.style.cssText = '-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;position:absolute;background: #7f7f7f;background:rgba(0,0,0,0.5);border: 1px solid #fafafa;border:1px solid rgba(255,255,255,0.9);border-radius:3px';
 	}
 
 	indicator.className = 'iScrollIndicator';

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,7 +46,7 @@ var utils = (function () {
 	};
 
 	me.prefixPointerEvent = function (pointerEvent) {
-		return window.MSPointerEvent ? 
+		return window.MSPointerEvent ?
 			'MSPointer' + pointerEvent.charAt(9).toUpperCase() + pointerEvent.substr(10):
 			pointerEvent;
 	};
@@ -148,6 +148,30 @@ var utils = (function () {
 		}
 
 		return false;
+	};
+
+	me.preventDefault = function (event) {
+
+		// If preventDefault exists, run it on the original event
+		if ( event.preventDefault ) {
+		    event.preventDefault();
+
+		// Support: IE
+		// Otherwise set the returnValue property of the original event to false
+		} else {
+		    event.returnValue = false;
+		}
+	};
+
+	me.stopPropagation = function (event) {
+		// If stopPropagation exists, run it on the original event
+		if ( event.stopPropagation ) {
+		    event.stopPropagation();
+		}
+
+		// Support: IE
+		// Set the cancelBubble property of the original event to true
+		event.cancelBubble = true;
 	};
 
 	me.extend(me.eventType = {}, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,31 @@ var utils = (function () {
 	};
 
 	me.addEvent = function (el, type, fn, capture) {
-		el.addEventListener(type, fn, !!capture);
+		if (el.addEventListener) {
+
+		    // BBOS6 doesn't support handleEvent, catch and polyfill
+		    // take code from: http://www.thecssninja.com/javascript/handleevent
+		    try{
+		        el.addEventListener(type, fn, !!capture);
+		    } catch(e) {
+		        if (typeof fn === 'object' && fn.handleEvent) {
+		            el.addEventListener(type, function(e){
+		                // Bind fn as this and set first arg as event object
+		                fn.handleEvent.call(fn, e);
+		            }, !!capture)
+		        }
+		    }
+		} else {
+		    // check if the callback is an object and contains handleEvent
+		    if(typeof fn == "object" && fn.handleEvent) {
+		        el.attachEvent("on" + type, function(){
+		            // Bind fn as this
+		            fn.handleEvent.call(fn);
+		        });
+		    } else {
+		        el.attachEvent("on" + type, fn);
+		    }
+		}
 	};
 
 	me.removeEvent = function (el, type, fn, capture) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,11 @@ var utils = (function () {
 	};
 
 	me.removeEvent = function (el, type, fn, capture) {
-		el.removeEventListener(type, fn, !!capture);
+		if (el.removeEventListener) {
+			el.removeEventListener(type, fn, !!capture);
+		} else {
+			el.detachEvent('on'+type, fn);
+		}
 	};
 
 	me.prefixPointerEvent = function (pointerEvent) {

--- a/src/wheel/wheel.js
+++ b/src/wheel/wheel.js
@@ -16,8 +16,8 @@
 			return;
 		}
 
-		e.preventDefault();
-		e.stopPropagation();
+		utils.preventDefault(e);
+		utils.stopPropagation(e);
 
 		var wheelDeltaX, wheelDeltaY,
 			newX, newY,

--- a/src/zoom/zoom.js
+++ b/src/zoom/zoom.js
@@ -22,7 +22,7 @@
 		}
 
 		if ( this.options.preventDefault ) {
-			e.preventDefault();
+			utils.preventDefault(e);
 		}
 
 		var c1 = Math.abs( e.touches[0].pageX - e.touches[1].pageX ),
@@ -55,7 +55,7 @@
 		}
 
 		if ( this.options.preventDefault ) {
-			e.preventDefault();
+			utils.preventDefault(e);
 		}
 
 		var newX, newY,


### PR DESCRIPTION
I take iscroll in a company project, and we have many user with the browser of IE 6,7,8。but iscroll is not work fine under this browser, so I make some compatible for it. 

## registe event

make the addEvent work in IE by add attachEvent detachEvent when the addEventListener and removeEventListener is not support

the feature of handleEvent is not support in IE 6,7,8, so we need to make it by another way.

this code is take from [http://www.thecssninja.com/javascript/handleevent](http://www.thecssninja.com/javascript/handleevent)

## preventDefault and stopPropagation

preventDefault and stopPropagation is not support in the early IE version. This code is copy from jQuery's source code.

## event argument

in old IE, the event will not pass to the callback function, but set as window.event

## transform

when the transform is not set, position absolute should set to the scroller to make it move by set style left and top.
