### PR TITLE
update the snap current page info when call resetPosition

### DIFF
--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -594,7 +594,6 @@ IScroll.prototype = {
 			this.isInTransition = 1;
 		}
 
-
 		if ( this.options.snap ) {
 			var snap = this._nearestSnap(newX, newY);
 			this.currentPage = snap;
@@ -610,6 +609,7 @@ IScroll.prototype = {
 			this.directionY = 0;
 			easing = this.options.bounceEasing;
 		}
+
 
 // INSERT POINT: _end
 
@@ -657,6 +657,14 @@ IScroll.prototype = {
 		if ( x == this.x && y == this.y ) {
 			return false;
 		}
+
+
+		if ( this.options.snap ) {
+            this.currentPage = this._nearestSnap(x, y);
+        }
+
+
+// INSERT POINT: _reset
 
 		this.scrollTo(x, y, time, this.options.bounceEasing);
 

--- a/build/iscroll-lite.js
+++ b/build/iscroll-lite.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -601,6 +601,8 @@ IScroll.prototype = {
 		if ( x == this.x && y == this.y ) {
 			return false;
 		}
+
+// INSERT POINT: _reset
 
 		this.scrollTo(x, y, time, this.options.bounceEasing);
 

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -592,7 +592,6 @@ IScroll.prototype = {
 			this.isInTransition = 1;
 		}
 
-
 		if ( this.options.snap ) {
 			var snap = this._nearestSnap(newX, newY);
 			this.currentPage = snap;
@@ -608,6 +607,7 @@ IScroll.prototype = {
 			this.directionY = 0;
 			easing = this.options.bounceEasing;
 		}
+
 
 // INSERT POINT: _end
 
@@ -655,6 +655,14 @@ IScroll.prototype = {
 		if ( x == this.x && y == this.y ) {
 			return false;
 		}
+
+
+		if ( this.options.snap ) {
+            this.currentPage = this._nearestSnap(x, y);
+        }
+
+
+// INSERT POINT: _reset
 
 		this.scrollTo(x, y, time, this.options.bounceEasing);
 

--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -592,7 +592,6 @@ IScroll.prototype = {
 			this.isInTransition = 1;
 		}
 
-
 		if ( this.options.snap ) {
 			var snap = this._nearestSnap(newX, newY);
 			this.currentPage = snap;
@@ -608,6 +607,7 @@ IScroll.prototype = {
 			this.directionY = 0;
 			easing = this.options.bounceEasing;
 		}
+
 
 // INSERT POINT: _end
 
@@ -655,6 +655,14 @@ IScroll.prototype = {
 		if ( x == this.x && y == this.y ) {
 			return false;
 		}
+
+
+		if ( this.options.snap ) {
+            this.currentPage = this._nearestSnap(x, y);
+        }
+
+
+// INSERT POINT: _reset
 
 		this.scrollTo(x, y, time, this.options.bounceEasing);
 

--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.1.3 ~ (c) 2008-2014 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.1.3 ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -583,7 +583,6 @@ IScroll.prototype = {
 			this.isInTransition = 1;
 		}
 
-
 		if ( this.options.snap ) {
 			var snap = this._nearestSnap(newX, newY);
 			this.currentPage = snap;
@@ -599,6 +598,7 @@ IScroll.prototype = {
 			this.directionY = 0;
 			easing = this.options.bounceEasing;
 		}
+
 
 // INSERT POINT: _end
 
@@ -646,6 +646,14 @@ IScroll.prototype = {
 		if ( x == this.x && y == this.y ) {
 			return false;
 		}
+
+
+		if ( this.options.snap ) {
+            this.currentPage = this._nearestSnap(x, y);
+        }
+
+
+// INSERT POINT: _reset
 
 		this.scrollTo(x, y, time, this.options.bounceEasing);
 

--- a/src/core.js
+++ b/src/core.js
@@ -356,6 +356,8 @@ IScroll.prototype = {
 			return false;
 		}
 
+// INSERT POINT: _reset
+
 		this.scrollTo(x, y, time, this.options.bounceEasing);
 
 		return true;

--- a/src/snap/_end.js
+++ b/src/snap/_end.js
@@ -1,4 +1,3 @@
-
 		if ( this.options.snap ) {
 			var snap = this._nearestSnap(newX, newY);
 			this.currentPage = snap;

--- a/src/snap/_reset.js
+++ b/src/snap/_reset.js
@@ -1,0 +1,4 @@
+
+		if ( this.options.snap ) {
+            this.currentPage = this._nearestSnap(x, y);
+        }

--- a/src/snap/build.json
+++ b/src/snap/build.json
@@ -2,6 +2,7 @@
 	"insert": {
 		"OPTIONS": "\t\tsnapThreshold: 0.334,",
 		"_end": "snap/_end.js",
+		"_reset": "snap/_reset.js",
 		"refresh": "snap/refresh.js",
 		"_init": "\t\tif ( this.options.snap ) {\n\t\t\tthis._initSnap();\n\t\t}"
 	}


### PR DESCRIPTION
update currentPage for snap case: take the `demos/carousel` as example, if we are at the second snap item, and scroll left to the boundary, then `_end` method will return after reset position, this will not update the current page info. Thus if we made a slight scroll, the behavior will be weird.