### PR TITLE
Remove unnecessary function call

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -504,7 +504,9 @@ IScroll.prototype = {
 
 	_transitionTime: function (time) {
 		time = time || 0;
-
+		if(!this.options.useTransition) {
+			return;
+		}
 		this.scrollerStyle[utils.style.transitionDuration] = time + 'ms';
 
 		if ( !time && utils.isBadAndroid ) {


### PR DESCRIPTION
if 'useTransition' option is 'false', '_transitionTime' method should not call. 
but, Whenever touchstart/mousedown/pointerdown event is fired, '_transitionTime' method is called.

I modified _transitionTime method.