### PR TITLE
destroy() does not cancel timeouts

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -85,7 +85,8 @@ IScroll.prototype = {
 
 	destroy: function () {
 		this._initEvents(true);
-
+		clearTimeout(this.resizeTimeout);
+		this.resizeTimeout = null;
 		this._execEvent('destroy');
 	},
 

--- a/src/indicator/indicator.js
+++ b/src/indicator/indicator.js
@@ -114,6 +114,10 @@ Indicator.prototype = {
 	},
 
 	destroy: function () {
+		if ( this.options.fadeScrollbars ) {
+			clearTimeout(this.fadeTimeout);
+			this.fadeTimeout = null;
+		}		
 		if ( this.options.interactive ) {
 			utils.removeEvent(this.indicator, 'touchstart', this);
 			utils.removeEvent(this.indicator, utils.prefixPointerEvent('pointerdown'), this);

--- a/src/wheel/wheel.js
+++ b/src/wheel/wheel.js
@@ -5,6 +5,8 @@
 		utils.addEvent(this.wrapper, 'DOMMouseScroll', this);
 
 		this.on('destroy', function () {
+			clearTimeout(this.wheelTimeout);
+			this.wheelTimeout = null;
 			utils.removeEvent(this.wrapper, 'wheel', this);
 			utils.removeEvent(this.wrapper, 'mousewheel', this);
 			utils.removeEvent(this.wrapper, 'DOMMouseScroll', this);


### PR DESCRIPTION
If timer was set and 'destroy' method was called, you could be faced a problem.
resize or fade actions will be called twice.

So I add some codes in destroy task.
- cancel resizeTimeout
- cancel fadeTimeout
- cancel wheelTimout

Reference issue #924 