### PR TITLE
Update iscroll.js - Added "beforePageChanged" event

### DIFF
--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -1222,10 +1222,23 @@ IScroll.prototype = {
 						Math.min(Math.abs(this.x - this.startX), 1000),
 						Math.min(Math.abs(this.y - this.startY), 1000)
 					), 300);
+					
+			var pageX = this.currentPage.pageX + this.directionX,
+				pageY = this.currentPage.pageY + this.directionY;
+					x = this.pages[pageX][pageY].x,
+					y = this.pages[pageX][pageY].y;
+			this.targetPage = {
+						x: x,
+						y: y,
+						pageX: pageX ,
+						pageY: pageY 
+					};	
+			this._execEvent("beforePageChanged");
+						
 
 			this.goToPage(
-				this.currentPage.pageX + this.directionX,
-				this.currentPage.pageY + this.directionY,
+				pageX,
+				pageY,
 				time
 			);
 		});
@@ -1297,7 +1310,15 @@ IScroll.prototype = {
 
 			y = this.pages[0][m].y;
 		}
-
+		
+		this.targetPage = {
+			x: x,
+			y: y,
+			pageX: i,
+			pageY: m
+		};	
+		this._execEvent("beforePageChanged");
+		
 		return {
 			x: x,
 			y: y,


### PR DESCRIPTION
When "snap" option is not false, the target page is calculated and it is different than the currentPage, it initializes the property "targetPage" with the detailes x position, y position, pageX and pageY indexes of the page that the IScroll is going to and fires an event called "beforePageChanged".,

How to use it:

var myScroll = new IScroll('#wrapper', { scrollX: true, scrollY: false, momentum: false, snap: true, snapSpeed: 400});

myScroll,on("beforePageChanged", function(){
    alert(this.targetPage.pageX);
});