### PR TITLE
Fix wheel.js for horizontal scroll

### DIFF
--- a/src/wheel/wheel.js
+++ b/src/wheel/wheel.js
@@ -57,7 +57,8 @@
 		wheelDeltaY *= this.options.invertWheelDirection;
 
 		if ( !this.hasVerticalScroll ) {
-			wheelDeltaX = wheelDeltaY;
+			if (Math.abs(wheelDeltaY) > Math.abs(wheelDeltaX))
+				wheelDeltaX = wheelDeltaY;
 			wheelDeltaY = 0;
 		}
 


### PR DESCRIPTION
Fix wheel.js for horizontal scroll, when wheelDeltaX more then wheelDeltaY. In this case don't change wheelDeltaX.
This bug on MacBook Pro, when use tachpad & horizontal scroll.