### PR TITLE
Fix division by zero in _wheelZoom

### DIFF
--- a/src/zoom/zoom.js
+++ b/src/zoom/zoom.js
@@ -142,8 +142,9 @@
 	},
 
 	_wheelZoom: function (e) {
-		var wheelDeltaY,
+		var deltaY,
 			deltaScale,
+			sign,
 			that = this;
 
 		// Execute the zoomEnd event after 400ms the wheel stopped scrolling
@@ -153,18 +154,19 @@
 		}, 400);
 
 		if ( 'deltaX' in e ) {
-			wheelDeltaY = -e.deltaY / Math.abs(e.deltaY);
+			deltaY = -e.deltaY;
 		} else if ('wheelDeltaX' in e) {
-			wheelDeltaY = e.wheelDeltaY / Math.abs(e.wheelDeltaY);
+			deltaY = e.wheelDeltaY;
 		} else if('wheelDelta' in e) {
-			wheelDeltaY = e.wheelDelta / Math.abs(e.wheelDelta);
+			deltaY = e.wheelDelta;
 		} else if ('detail' in e) {
-			wheelDeltaY = -e.detail / Math.abs(e.wheelDelta);
+			deltaY = -e.detail;
 		} else {
 			return;
 		}
 
-		deltaScale = this.scale + wheelDeltaY / 5;
+		sign = deltaY ? deltaY < 0 ? -1 : 1 : 0;
+		deltaScale = this.scale + sign * 1/5;
 
 		this.zoom(deltaScale, e.pageX, e.pageY, 0);
 	},


### PR DESCRIPTION
Use an alternative way to get the sign of deltaY and make it more
obvious that it is only used to get a signed unity factor.