### PR TITLE
set currentPage on scrollToElement

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -482,6 +482,25 @@ IScroll.prototype = {
 
 		pos.left -= this.wrapperOffset.left;
 		pos.top  -= this.wrapperOffset.top;
+		
+        	// set current page to page containing element scrolling to
+		var self = this;
+		this.pages.forEach(function (page, id) {
+			var minWidth = page[0].width * id;
+			var maxWidth = minWidth + page[0].width;
+
+			var minHeight = page[0].height * id;
+			var maxHeight = minHeight + page[0].height;
+
+			if (Math.abs(pos.left) >= minWidth && Math.abs(pos.left) < maxWidth) {
+				self.currentPage.x = minWidth;
+				self.currentPage.pageX = id;
+			}
+			if (Math.abs(pos.top) >= minHeight && Math.abs(pos.top) < maxHeight) {
+				self.currentPage.y = minHeight;
+				self.currentPage.pageY = id;
+			}
+		});
 
 		// if offsetX/Y are true we center the element to the screen
 		if ( offsetX === true ) {


### PR DESCRIPTION
This is especially needed when scrolling to an element on page load. Maybe there is a better way to do it. :)