### PR TITLE
add VUPBoundary VDOWNboundary options so that pull-refresh is possible when content didn't overflow wrapper

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -23,7 +23,10 @@ function IScroll (el, options) {
 
 		HWCompositing: true,
 		useTransition: true,
-		useTransform: true
+		useTransform: true,
+
+		VUPBoundary:true,   //true : respect v-boundary when not overflow, false: can scroll when not overflow
+		VDOWNboundary:true,
 	};
 
 	for ( var i in options ) {
@@ -213,7 +216,15 @@ IScroll.prototype = {
 		}
 
 		deltaX = this.hasHorizontalScroll ? deltaX : 0;
-		deltaY = this.hasVerticalScroll ? deltaY : 0;
+
+		// Still scroll when wrapper is not over-flow by scroller
+		if(!this.options.VUPBoundary && deltaY < 0) {
+			deltaY = deltaY;
+		}else if(!this.options.VDOWNboundary && deltaY > 0) {
+			deltaY = deltaY;
+		}else {
+			deltaY = this.hasVerticalScroll ? deltaY : 0;
+		}
 
 		newX = this.x + deltaX;
 		newY = this.y + deltaY;


### PR DESCRIPTION
Pull-refresh is only possible when wrapper is overflowed by content. Obviously, this will be a bug in situations where content(scroller) is not long enough to overflow the wrapper. 

So I add VUPBoundary and VDOWNboundary options. By setting them to FALSE, content can still scroll even if the content is short and the wrapper is not over-flowed.

