### PR TITLE
Add optional `touchWaitDuration` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ In this case you'd listen to `myCustomTapEvent`.
 
 Default: `false`
 
+### <small>options.</small>touchWaitDuration<br/><small>options.</small>touchWaitDuration
+
+Allows refinement of the timeout that constitutes what is considered a momentum scroll.
+
+Default: `300`
+
 <h2 id="scrollbars">Scrollbars</h2>
 
 The scrollbars are more than just what the name suggests. In fact internally they are referenced as *indicators*.

--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -303,6 +303,7 @@ function IScroll (el, options) {
 		scrollY: true,
 		directionLockThreshold: 5,
 		momentum: true,
+		touchWaitDuration: 300,
 
 		bounce: true,
 		bounceTime: 600,
@@ -512,7 +513,7 @@ IScroll.prototype = {
 		absDistY		= Math.abs(this.distY);
 
 		// We need to move at least 10 pixels for the scrolling to initiate
-		if ( timestamp - this.endTime > 300 && (absDistX < 10 && absDistY < 10) ) {
+		if ( timestamp - this.endTime > this.options.touchWaitDuration && (absDistX < 10 && absDistY < 10) ) {
 			return;
 		}
 
@@ -641,7 +642,7 @@ IScroll.prototype = {
 		}
 
 		// start momentum animation if needed
-		if ( this.options.momentum && duration < 300 ) {
+		if ( this.options.momentum && duration < this.options.touchWaitDuration ) {
 			momentumX = this.hasHorizontalScroll ? utils.momentum(this.x, this.startX, duration, this.maxScrollX, this.options.bounce ? this.wrapperWidth : 0, this.options.deceleration) : { destination: newX, duration: 0 };
 			momentumY = this.hasVerticalScroll ? utils.momentum(this.y, this.startY, duration, this.maxScrollY, this.options.bounce ? this.wrapperHeight : 0, this.options.deceleration) : { destination: newY, duration: 0 };
 			newX = momentumX.destination;

--- a/build/iscroll-lite.js
+++ b/build/iscroll-lite.js
@@ -296,6 +296,7 @@ function IScroll (el, options) {
 		scrollY: true,
 		directionLockThreshold: 5,
 		momentum: true,
+		touchWaitDuration: 300,
 
 		bounce: true,
 		bounceTime: 600,
@@ -479,7 +480,7 @@ IScroll.prototype = {
 		absDistY		= Math.abs(this.distY);
 
 		// We need to move at least 10 pixels for the scrolling to initiate
-		if ( timestamp - this.endTime > 300 && (absDistX < 10 && absDistY < 10) ) {
+		if ( timestamp - this.endTime > this.options.touchWaitDuration && (absDistX < 10 && absDistY < 10) ) {
 			return;
 		}
 
@@ -541,7 +542,7 @@ IScroll.prototype = {
 
 /* REPLACE START: _move */
 
-		if ( timestamp - this.startTime > 300 ) {
+		if ( timestamp - this.startTime > this.options.touchWaitDuration ) {
 			this.startTime = timestamp;
 			this.startX = this.x;
 			this.startY = this.y;
@@ -602,7 +603,7 @@ IScroll.prototype = {
 		}
 
 		// start momentum animation if needed
-		if ( this.options.momentum && duration < 300 ) {
+		if ( this.options.momentum && duration < this.options.touchWaitDuration ) {
 			momentumX = this.hasHorizontalScroll ? utils.momentum(this.x, this.startX, duration, this.maxScrollX, this.options.bounce ? this.wrapperWidth : 0, this.options.deceleration) : { destination: newX, duration: 0 };
 			momentumY = this.hasVerticalScroll ? utils.momentum(this.y, this.startY, duration, this.maxScrollY, this.options.bounce ? this.wrapperHeight : 0, this.options.deceleration) : { destination: newY, duration: 0 };
 			newX = momentumX.destination;

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -302,6 +302,7 @@ function IScroll (el, options) {
 		scrollY: true,
 		directionLockThreshold: 5,
 		momentum: true,
+		touchWaitDuration: 300,
 
 		bounce: true,
 		bounceTime: 600,
@@ -510,7 +511,7 @@ IScroll.prototype = {
 		absDistY		= Math.abs(this.distY);
 
 		// We need to move at least 10 pixels for the scrolling to initiate
-		if ( timestamp - this.endTime > 300 && (absDistX < 10 && absDistY < 10) ) {
+		if ( timestamp - this.endTime > this.options.touchWaitDuration && (absDistX < 10 && absDistY < 10) ) {
 			return;
 		}
 
@@ -639,7 +640,7 @@ IScroll.prototype = {
 		}
 
 		// start momentum animation if needed
-		if ( this.options.momentum && duration < 300 ) {
+		if ( this.options.momentum && duration < this.options.touchWaitDuration ) {
 			momentumX = this.hasHorizontalScroll ? utils.momentum(this.x, this.startX, duration, this.maxScrollX, this.options.bounce ? this.wrapperWidth : 0, this.options.deceleration) : { destination: newX, duration: 0 };
 			momentumY = this.hasVerticalScroll ? utils.momentum(this.y, this.startY, duration, this.maxScrollY, this.options.bounce ? this.wrapperHeight : 0, this.options.deceleration) : { destination: newY, duration: 0 };
 			newX = momentumX.destination;

--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -305,6 +305,7 @@ function IScroll (el, options) {
 		scrollY: true,
 		directionLockThreshold: 5,
 		momentum: true,
+		touchWaitDuration: 300,
 
 		bounce: true,
 		bounceTime: 600,
@@ -516,7 +517,7 @@ IScroll.prototype = {
 		absDistY		= Math.abs(this.distY);
 
 		// We need to move at least 10 pixels for the scrolling to initiate
-		if ( timestamp - this.endTime > 300 && (absDistX < 10 && absDistY < 10) ) {
+		if ( timestamp - this.endTime > this.options.touchWaitDuration && (absDistX < 10 && absDistY < 10) ) {
 			return;
 		}
 
@@ -578,7 +579,7 @@ IScroll.prototype = {
 
 /* REPLACE START: _move */
 
-		if ( timestamp - this.startTime > 300 ) {
+		if ( timestamp - this.startTime > this.options.touchWaitDuration ) {
 			this.startTime = timestamp;
 			this.startX = this.x;
 			this.startY = this.y;
@@ -639,7 +640,7 @@ IScroll.prototype = {
 		}
 
 		// start momentum animation if needed
-		if ( this.options.momentum && duration < 300 ) {
+		if ( this.options.momentum && duration < this.options.touchWaitDuration ) {
 			momentumX = this.hasHorizontalScroll ? utils.momentum(this.x, this.startX, duration, this.maxScrollX, this.options.bounce ? this.wrapperWidth : 0, this.options.deceleration) : { destination: newX, duration: 0 };
 			momentumY = this.hasVerticalScroll ? utils.momentum(this.y, this.startY, duration, this.maxScrollY, this.options.bounce ? this.wrapperHeight : 0, this.options.deceleration) : { destination: newY, duration: 0 };
 			newX = momentumX.destination;

--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -302,6 +302,7 @@ function IScroll (el, options) {
 		scrollY: true,
 		directionLockThreshold: 5,
 		momentum: true,
+		touchWaitDuration: 300,
 
 		bounce: true,
 		bounceTime: 600,
@@ -507,7 +508,7 @@ IScroll.prototype = {
 		absDistY		= Math.abs(this.distY);
 
 		// We need to move at least 10 pixels for the scrolling to initiate
-		if ( timestamp - this.endTime > 300 && (absDistX < 10 && absDistY < 10) ) {
+		if ( timestamp - this.endTime > this.options.touchWaitDuration && (absDistX < 10 && absDistY < 10) ) {
 			return;
 		}
 
@@ -569,7 +570,7 @@ IScroll.prototype = {
 
 /* REPLACE START: _move */
 
-		if ( timestamp - this.startTime > 300 ) {
+		if ( timestamp - this.startTime > this.options.touchWaitDuration ) {
 			this.startTime = timestamp;
 			this.startX = this.x;
 			this.startY = this.y;
@@ -630,7 +631,7 @@ IScroll.prototype = {
 		}
 
 		// start momentum animation if needed
-		if ( this.options.momentum && duration < 300 ) {
+		if ( this.options.momentum && duration < this.options.touchWaitDuration ) {
 			momentumX = this.hasHorizontalScroll ? utils.momentum(this.x, this.startX, duration, this.maxScrollX, this.options.bounce ? this.wrapperWidth : 0, this.options.deceleration) : { destination: newX, duration: 0 };
 			momentumY = this.hasVerticalScroll ? utils.momentum(this.y, this.startY, duration, this.maxScrollY, this.options.bounce ? this.wrapperHeight : 0, this.options.deceleration) : { destination: newY, duration: 0 };
 			newX = momentumX.destination;

--- a/src/core.js
+++ b/src/core.js
@@ -15,6 +15,7 @@ function IScroll (el, options) {
 		scrollY: true,
 		directionLockThreshold: 5,
 		momentum: true,
+		touchWaitDuration: 300,
 
 		bounce: true,
 		bounceTime: 600,
@@ -198,7 +199,7 @@ IScroll.prototype = {
 		absDistY		= Math.abs(this.distY);
 
 		// We need to move at least 10 pixels for the scrolling to initiate
-		if ( timestamp - this.endTime > 300 && (absDistX < 10 && absDistY < 10) ) {
+		if ( timestamp - this.endTime > this.options.touchWaitDuration && (absDistX < 10 && absDistY < 10) ) {
 			return;
 		}
 
@@ -260,7 +261,7 @@ IScroll.prototype = {
 
 /* REPLACE START: _move */
 
-		if ( timestamp - this.startTime > 300 ) {
+		if ( timestamp - this.startTime > this.options.touchWaitDuration ) {
 			this.startTime = timestamp;
 			this.startX = this.x;
 			this.startY = this.y;
@@ -321,7 +322,7 @@ IScroll.prototype = {
 		}
 
 		// start momentum animation if needed
-		if ( this.options.momentum && duration < 300 ) {
+		if ( this.options.momentum && duration < this.options.touchWaitDuration ) {
 			momentumX = this.hasHorizontalScroll ? utils.momentum(this.x, this.startX, duration, this.maxScrollX, this.options.bounce ? this.wrapperWidth : 0, this.options.deceleration) : { destination: newX, duration: 0 };
 			momentumY = this.hasVerticalScroll ? utils.momentum(this.y, this.startY, duration, this.maxScrollY, this.options.bounce ? this.wrapperHeight : 0, this.options.deceleration) : { destination: newY, duration: 0 };
 			newX = momentumX.destination;


### PR DESCRIPTION
I was experiencing some jump scrolling happening when doing lots of repeated small drags on an iScroll pane. Having this duration be optional allows developers with acute OCD to set this duration as they see fit. By default, however, it is a no-op since it falls back to `300`.

<3 <3 