### PR TITLE
Enable reproducible building

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 var hint = require("jshint").JSHINT;
 var uglify = require('uglify-js');
 
-var banner = '/*! iScroll v' + pkg.version + ' ~ (c) 2008-' + (new Date().getFullYear()) + ' Matteo Spinelli ~ http://cubiq.org/license */\n';
+var banner = '/*! iScroll v' + pkg.version + ' ~ (c) 2008-2015 Matteo Spinelli ~ http://cubiq.org/license */\n';
 
 var releases = {
 	lite: {


### PR DESCRIPTION
The current year is embedded into the head of javascript files.
Use a fixed date instead.

Reproducible builds helps verifying that the generated files
are generated from the original sources. See more details at:
https://reproducible-builds.org/