### PR TITLE
fix console error on destroy

### DIFF
--- a/src/indicator/indicator.js
+++ b/src/indicator/indicator.js
@@ -145,7 +145,7 @@ Indicator.prototype = {
 			utils.removeEvent(window, 'mouseup', this);
 		}
 
-		if ( this.options.defaultScrollbars ) {
+		if ( this.options.defaultScrollbars && this.wrapper.parentNode ) {
 			this.wrapper.parentNode.removeChild(this.wrapper);
 		}
 	},


### PR DESCRIPTION
I have this console error on iscroll destroy:
https://drive.google.com/file/d/0Bxtv10NlSOEbVzJMaWt0eVAxdjQ/view?usp=sharing

So,I suggest to add checking for parentNode.
