### PR TITLE
Do not execute event handler if not enabled and event type is touchca…

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -180,6 +180,7 @@ var utils = (function () {
 		touchstart: 1,
 		touchmove: 1,
 		touchend: 1,
+		touchcancel: 1,
 
 		mousedown: 2,
 		mousemove: 2,


### PR DESCRIPTION
…ncel.

handleEvent registers event listeners for the various touch events: touchstart, touchmove, touchend AND touchcancel.

Event listeners check the state of IScroll and the event type and decide if they can run:

> ```
>   if ( !this.enabled || utils.eventType[e.type] !== this.initiated ) {
>       return;
>   }
> ```

this.enabled ist set to true in the construct method IScroll.
utils.eventType is undefined for e.type === "touchcancel", as is this.initiated if you are scrolling outside your wrapper and _start was not executed.

Both expressions evaluate to false and thus the event listeners execute.

(SEO: Found the problem on Android 4.4.2 Webview, which emits touchcancel events)
