### PR TITLE
Allow mouse and touch events at the same time

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -9,7 +9,7 @@ function IScroll (el, options) {
 // INSERT POINT: OPTIONS
 		disablePointer : !utils.hasPointer,
 		disableTouch : utils.hasPointer || !utils.hasTouch,
-		disableMouse : utils.hasPointer || utils.hasTouch,
+		disableMouse : utils.hasPointer,
 		startX: 0,
 		startY: 0,
 		scrollY: true,

--- a/src/default/handleEvent.js
+++ b/src/default/handleEvent.js
@@ -2,6 +2,7 @@
 	handleEvent: function (e) {
 		switch ( e.type ) {
 			case 'touchstart':
+				e.stopPropagation();
 			case 'pointerdown':
 			case 'MSPointerDown':
 			case 'mousedown':


### PR DESCRIPTION
Fixes #1092

There is some question on if `e.preventDefault()` should be on the `touchstart` too. This works fine for a mouse and touch interface and a pure mouse interface. I haven't tested a pure touch interface yet.

Inpiration

http://stackoverflow.com/questions/13655919/how-to-bind-both-mousedown-and-touchstart-but-not-respond-to-both-android-jqu