### PR TITLE
Fix the scroller for pointer events

### DIFF
--- a/demos/event-passthrough/index.html
+++ b/demos/event-passthrough/index.html
@@ -79,6 +79,7 @@ body {
 	-ms-text-size-adjust: none;
 	-o-text-size-adjust: none;
 	text-size-adjust: none;
+	touch-action: none;
 }
 
 #scroller ul {


### PR DESCRIPTION
Add a touch-action:none property to suppress browser action on the scroller so that the scroller receives all pointer events. See #1100.