### PR TITLE
Suggestions on how to change the wheel zoom sensitivity.

### DIFF
--- a/src/zoom/zoom.js
+++ b/src/zoom/zoom.js
@@ -164,7 +164,7 @@
 			return;
 		}
 
-		deltaScale = this.scale + wheelDeltaY / 5;
+		deltaScale = this.scale + wheelDeltaY * this.options.mouseWheelSpeed / 100;
 
 		this.zoom(deltaScale, e.pageX, e.pageY, 0);
 	},


### PR DESCRIPTION
The mouseWheelSpeed option has no use when using wheel zoom action.
So it would be better to use as sensitivity option of wheel zoom action.

wheelDeltaY / 5 * (this.options.mouseWheelSpeed / 20)  ==  wheelDeltaY * this.options.mouseWheelSpeed / 100

If the option is not set separately, the original sensitivity is maintained.