### PR TITLE
Stop vertical snap from creating pages past the scrollable range.

### DIFF
--- a/src/snap/snap.js
+++ b/src/snap/snap.js
@@ -57,7 +57,10 @@
 					rect = utils.getRect(el[i]);
 					if ( i === 0 || rect.left <= utils.getRect(el[i-1]).left ) {
 						m = 0;
-						n++;
+						// Don't add more vertical pages for elements past the scrollable range.
+						if ( -rect.top > this.maxScrollY ) {
+							n++;
+						}
 					}
 
 					if ( !this.pages[m] ) {

--- a/src/snap/snap.js
+++ b/src/snap/snap.js
@@ -62,6 +62,7 @@
 							n++;
 						}
 					}
+					n = Math.max(0, n);
 
 					if ( !this.pages[m] ) {
 						this.pages[m] = [];


### PR DESCRIPTION
Hi there,

this pull request fixes an issue with the snap feature in vertically scrolled lists where you could increase the page counter past the scrollable range using next() or the mouse wheel.
I attached a demo page with a fairly minimal test case.

The setup is this:
- The list has 10 vertical elements, but there is only room to show 5.
- iScroll is created with snap on li and mouseWheel.
- The links on the right can be used to scroll to the previous/next page.

Initially, the page count starts at 0. You can scroll 3 times until you reach the end of the list. The page count is now at 3 but subsequent clicks on "Next" will increase the page count up to 9 so that you would have to click "Prev" multiple times before the list actually scrolls up one element again.

Cheers
Daniel

Attachment: Demo page. Extract next to the other demos.
[snap-max-scroll.zip](https://github.com/cubiq/iscroll/files/820903/snap-max-scroll.zip)
