### PR TITLE
resetPosition should verify changes to the negative side of axis X

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -361,7 +361,7 @@ IScroll.prototype = {
 
 		time = time || 0;
 
-		if ( !this.hasHorizontalScroll || this.x > 0 ) {
+		if ( !this.hasHorizontalScroll || this.x !== 0 ) {
 			x = 0;
 		} else if ( this.x < this.maxScrollX ) {
 			x = this.maxScrollX;


### PR DESCRIPTION
Problem: Had a popup that had multiple tabs inside of it. In order to allow the user to see all of the tab headers used horizontal scrolling but when the user slides to the left side in order to see the last headers, resetPosition would not reset the X,as it was negative.

Possible solution: changed verification so it would reset the X as long as it was changed from 0.

PS: If any corrections were made on this matter, I could not find'em.