### PR TITLE
I need this feature, this is just an example.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/core.js
+++ b/src/core.js
@@ -173,6 +173,17 @@ IScroll.prototype = {
 		this._execEvent('beforeScrollStart');
 	},
 
+    // NEW FEATURE:
+    // user can lock scroll Y for certain direction, used by pull-to-refresh scenarios like(https://github.com/owenliang/pullToRefresh)
+    lockScrollUp: function() {
+        this.isScrollUpLocked = true;
+    },
+
+    unlockScrollUp: function() {
+        this.isScrollUpLocked = false;
+    },
+    ////////////////////////////////////////
+
 	_move: function (e) {
 		if ( !this.enabled || utils.eventType[e.type] !== this.initiated ) {
 			return;

--- a/src/core.js
+++ b/src/core.js
@@ -247,6 +247,10 @@ IScroll.prototype = {
 		deltaX = this.hasHorizontalScroll ? deltaX : 0;
 		deltaY = this.hasVerticalScroll ? deltaY : 0;
 
+        // NEW FEATURE:
+        // user can lock scroll Y for certain direction, used by pull-to-refresh-like scenarios
+        deltaY = deltaY < 0 && this.isScrollUpLocked ? 0 : deltaY;
+
 		newX = this.x + deltaX;
 		newY = this.y + deltaY;
 


### PR DESCRIPTION
When I implement the pull-to-refresh plugin(https://github.com/owenliang/pullToRefresh), I need to lock the iscroll's scrolling-Y for certain direction when user pull up the "pull-down-to-refresh" image.

There is a API called disable/enable, but they affect all direction, MY need is to disable certain direction.

The code works only for my project, but the feature may be added to iscroll5's API, please take a look, thanks.