### PR TITLE
Emit events on _translate as well

### DIFF
--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -966,6 +966,10 @@ IScroll.prototype = {
 		this.x = x;
 		this.y = y;
 
+		if ( this.options.probeType > 1 ) {
+			this._execEvent('scroll');
+		}
+
 // INSERT POINT: _translate
 
 	},

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -984,6 +984,10 @@ IScroll.prototype = {
 	}
 
 
+		if ( this.options.probeType > 1 ) {
+			this._execEvent('scroll');
+		}
+
 // INSERT POINT: _translate
 
 	},

--- a/src/probe/build.json
+++ b/src/probe/build.json
@@ -2,6 +2,7 @@
 	"insert": {
 		"NORMALIZATION": "\tif ( this.options.probeType == 3 ) {\n\t\tthis.options.useTransition = false;\t}",
 		"_wheel": "\t\tif ( this.options.probeType > 1 ) {\n\t\t\tthis._execEvent('scroll');\n\t\t}",
+		"_translate": "\t\tif ( this.options.probeType > 1 ) {\n\t\t\tthis._execEvent('scroll');\n\t\t}",
 		"indicator._move": "probe/indicator._move.js"
 	},
 	"replace": {


### PR DESCRIPTION
This closes https://github.com/cubiq/iscroll/issues/1217

When using the `keybindings` option and controlling the slider with the keyboard `_translate` is used instead of `_animate`. So far `_translate` didn't fire any events.
That caused inconsistencies: I had `probeType = 3` to get a pixel precision feedback about every movement of the slider. But by using the keybindings option I could move the slider without my listeners being called.