### PR TITLE
iscroll not working in Android latest version 6.0.1 and chrome beta

### DIFF
--- a/demos/zoom/index.html
+++ b/demos/zoom/index.html
@@ -1,167 +1,174 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
 
-<title>iScroll demo: zoom</title>
+    <title>iScroll demo: zoom</title>
 
-<script type="text/javascript" src="../../build/iscroll-zoom.js"></script>
-<script type="text/javascript" src="../demoUtils.js"></script>
-<script type="text/javascript">
+    <script type="text/javascript" src="../../build/iscroll-zoom.js"></script>
+    <script type="text/javascript" src="../demoUtils.js"></script>
+    <script type="text/javascript">
 
-var myScroll;
+        var myScroll;
 
-function loaded () {
-	myScroll = new IScroll('#wrapper', {
-		zoom: true,
-		scrollX: true,
-		scrollY: true,
-		mouseWheel: true,
-		wheelAction: 'zoom'
-	});
-}
+        function loaded() {
+            myScroll = new IScroll('#wrapper', {
+                zoom: true,
+                scrollX: true,
+                scrollY: true,
+                mouseWheel: true,
+                wheelAction: 'zoom',
+                click: true,// support click evt
+                disablePointer: true, // important to disable the pointer events that causes the issues
+                disableTouch: false, // false if you want the slider to be usable with touch devices
+                disableMouse: false // false if you want the slider to be usable with a mouse (desktop)
+            });
+        }
 
-document.addEventListener('touchmove', function (e) { e.preventDefault(); }, isPassive() ? {
-	capture: false,
-	passive: false
-} : false);
+        document.addEventListener('touchmove', function (e) {
+            e.preventDefault();
+        }, isPassive() ? {
+            capture: false,
+            passive: false
+        } : false);
 
-</script>
+    </script>
 
-<style type="text/css">
-* {
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	box-sizing: border-box;
-}
+    <style type="text/css">
+        * {
+            -webkit-box-sizing: border-box;
+            -moz-box-sizing: border-box;
+            box-sizing: border-box;
+        }
 
-html {
-	-ms-touch-action: none;
-}
+        html {
+            -ms-touch-action: none;
+        }
 
-body,ul,li {
-	padding: 0;
-	margin: 0;
-	border: 0;
-}
+        body, ul, li {
+            padding: 0;
+            margin: 0;
+            border: 0;
+        }
 
-body {
-	font-size: 12px;
-	font-family: ubuntu, helvetica, arial;
-	overflow: hidden; /* this is important to prevent the whole page to bounce */
-}
+        body {
+            font-size: 12px;
+            font-family: ubuntu, helvetica, arial;
+            overflow: hidden; /* this is important to prevent the whole page to bounce */
+        }
 
-#wrapper {
-	position: absolute;
-	z-index: 1;
-	top: 50px;
-	bottom: 50px;
-	left: 50px;
-	right: 50px;
-	background: #ccc;
-	overflow: hidden;
-}
+        #wrapper {
+            position: absolute;
+            z-index: 1;
+            top: 50px;
+            bottom: 50px;
+            left: 50px;
+            right: 50px;
+            background: #ccc;
+            overflow: hidden;
+        }
 
-#scroller {
-	position: absolute;
-	z-index: 1;
-	-webkit-tap-highlight-color: rgba(0,0,0,0);
-	width: 100%;
-	-webkit-transform: translateZ(0);
-	-moz-transform: translateZ(0);
-	-ms-transform: translateZ(0);
-	-o-transform: translateZ(0);
-	transform: translateZ(0);
-	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-	-webkit-text-size-adjust: none;
-	-moz-text-size-adjust: none;
-	-ms-text-size-adjust: none;
-	-o-text-size-adjust: none;
-	text-size-adjust: none;
-}
+        #scroller {
+            position: absolute;
+            z-index: 1;
+            -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+            width: 100%;
+            -webkit-transform: translateZ(0);
+            -moz-transform: translateZ(0);
+            -ms-transform: translateZ(0);
+            -o-transform: translateZ(0);
+            transform: translateZ(0);
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+            -webkit-text-size-adjust: none;
+            -moz-text-size-adjust: none;
+            -ms-text-size-adjust: none;
+            -o-text-size-adjust: none;
+            text-size-adjust: none;
+        }
 
-#scroller ul {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-	width: 100%;
-	text-align: left;
-}
+        #scroller ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            width: 100%;
+            text-align: left;
+        }
 
-#scroller li {
-	padding: 0 10px;
-	height: 40px;
-	line-height: 40px;
-	border-bottom: 1px solid #ccc;
-	border-top: 1px solid #fff;
-	background-color: #fafafa;
-	font-size: 14px;
-}
+        #scroller li {
+            padding: 0 10px;
+            height: 40px;
+            line-height: 40px;
+            border-bottom: 1px solid #ccc;
+            border-top: 1px solid #fff;
+            background-color: #fafafa;
+            font-size: 14px;
+        }
 
-</style>
+    </style>
 </head>
 <body onload="loaded()">
 
 <div id="wrapper">
-	<div id="scroller">
-		<ul>
-			<li>Pretty row 1</li>
-			<li>Pretty row 2</li>
-			<li>Pretty row 3</li>
-			<li>Pretty row 4</li>
-			<li>Pretty row 5</li>
-			<li>Pretty row 6</li>
-			<li>Pretty row 7</li>
-			<li>Pretty row 8</li>
-			<li>Pretty row 9</li>
-			<li>Pretty row 10</li>
-			<li>Pretty row 11</li>
-			<li>Pretty row 12</li>
-			<li>Pretty row 13</li>
-			<li>Pretty row 14</li>
-			<li>Pretty row 15</li>
-			<li>Pretty row 16</li>
-			<li>Pretty row 17</li>
-			<li>Pretty row 18</li>
-			<li>Pretty row 19</li>
-			<li>Pretty row 20</li>
-			<li>Pretty row 21</li>
-			<li>Pretty row 22</li>
-			<li>Pretty row 23</li>
-			<li>Pretty row 24</li>
-			<li>Pretty row 25</li>
-			<li>Pretty row 26</li>
-			<li>Pretty row 27</li>
-			<li>Pretty row 28</li>
-			<li>Pretty row 29</li>
-			<li>Pretty row 30</li>
-			<li>Pretty row 31</li>
-			<li>Pretty row 32</li>
-			<li>Pretty row 33</li>
-			<li>Pretty row 34</li>
-			<li>Pretty row 35</li>
-			<li>Pretty row 36</li>
-			<li>Pretty row 37</li>
-			<li>Pretty row 38</li>
-			<li>Pretty row 39</li>
-			<li>Pretty row 40</li>
-			<li>Pretty row 41</li>
-			<li>Pretty row 42</li>
-			<li>Pretty row 43</li>
-			<li>Pretty row 44</li>
-			<li>Pretty row 45</li>
-			<li>Pretty row 46</li>
-			<li>Pretty row 47</li>
-			<li>Pretty row 48</li>
-			<li>Pretty row 49</li>
-			<li>Pretty row 50</li>
-		</ul>
-	</div>
+    <div id="scroller">
+        <ul>
+            <li>Pretty row 1</li>
+            <li>Pretty row 2</li>
+            <li>Pretty row 3</li>
+            <li>Pretty row 4</li>
+            <li>Pretty row 5</li>
+            <li>Pretty row 6</li>
+            <li>Pretty row 7</li>
+            <li>Pretty row 8</li>
+            <li>Pretty row 9</li>
+            <li>Pretty row 10</li>
+            <li>Pretty row 11</li>
+            <li>Pretty row 12</li>
+            <li>Pretty row 13</li>
+            <li>Pretty row 14</li>
+            <li>Pretty row 15</li>
+            <li>Pretty row 16</li>
+            <li>Pretty row 17</li>
+            <li>Pretty row 18</li>
+            <li>Pretty row 19</li>
+            <li>Pretty row 20</li>
+            <li>Pretty row 21</li>
+            <li>Pretty row 22</li>
+            <li>Pretty row 23</li>
+            <li>Pretty row 24</li>
+            <li>Pretty row 25</li>
+            <li>Pretty row 26</li>
+            <li>Pretty row 27</li>
+            <li>Pretty row 28</li>
+            <li>Pretty row 29</li>
+            <li>Pretty row 30</li>
+            <li>Pretty row 31</li>
+            <li>Pretty row 32</li>
+            <li>Pretty row 33</li>
+            <li>Pretty row 34</li>
+            <li>Pretty row 35</li>
+            <li>Pretty row 36</li>
+            <li>Pretty row 37</li>
+            <li>Pretty row 38</li>
+            <li>Pretty row 39</li>
+            <li>Pretty row 40</li>
+            <li>Pretty row 41</li>
+            <li>Pretty row 42</li>
+            <li>Pretty row 43</li>
+            <li>Pretty row 44</li>
+            <li>Pretty row 45</li>
+            <li>Pretty row 46</li>
+            <li>Pretty row 47</li>
+            <li>Pretty row 48</li>
+            <li>Pretty row 49</li>
+            <li>Pretty row 50</li>
+        </ul>
+    </div>
 </div>
 
 </body>


### PR DESCRIPTION
fix bug in demo html.
reference: https://github.com/cubiq/iscroll/issues/1118

This is the same question in 5.2.0;You can try to set options like this

disablePointer: true, // important to disable the pointer events that causes the issues
disableTouch: false, // false if you want the slider to be usable with touch devices
disableMouse: false // false if you want the slider to be usable with a mouse (desktop)

disable pointer event，force to use touch