### PR TITLE
Fix SSR

### DIFF
--- a/build/iscroll-infinite.js
+++ b/build/iscroll-infinite.js
@@ -1,4 +1,8 @@
-/*! iScroll v5.2.0-snapshot ~ (c) 2008-2017 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.2.0-snapshot ~ (c) 2008-2018 Matteo Spinelli ~ http://cubiq.org/license */
+if (typeof window == 'undefined' && typeof module != 'undefined')
+  module.exports = { __disabled: 'No SSR support' };
+else
+
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||

--- a/build/iscroll-lite.js
+++ b/build/iscroll-lite.js
@@ -1,4 +1,8 @@
-/*! iScroll v5.2.0-snapshot ~ (c) 2008-2017 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.2.0-snapshot ~ (c) 2008-2018 Matteo Spinelli ~ http://cubiq.org/license */
+if (typeof window == 'undefined' && typeof module != 'undefined')
+  module.exports = { __disabled: 'No SSR support' };
+else
+
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||

--- a/build/iscroll-probe.js
+++ b/build/iscroll-probe.js
@@ -1,4 +1,8 @@
-/*! iScroll v5.2.0-snapshot ~ (c) 2008-2017 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.2.0-snapshot ~ (c) 2008-2018 Matteo Spinelli ~ http://cubiq.org/license */
+if (typeof window == 'undefined' && typeof module != 'undefined')
+  module.exports = { __disabled: 'No SSR support' };
+else
+
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||

--- a/build/iscroll-zoom.js
+++ b/build/iscroll-zoom.js
@@ -1,4 +1,8 @@
-/*! iScroll v5.2.0-snapshot ~ (c) 2008-2017 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.2.0-snapshot ~ (c) 2008-2018 Matteo Spinelli ~ http://cubiq.org/license */
+if (typeof window == 'undefined' && typeof module != 'undefined')
+  module.exports = { __disabled: 'No SSR support' };
+else
+
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||

--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -1,4 +1,8 @@
-/*! iScroll v5.2.0-snapshot ~ (c) 2008-2017 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.2.0-snapshot ~ (c) 2008-2018 Matteo Spinelli ~ http://cubiq.org/license */
+if (typeof window == 'undefined' && typeof module != 'undefined')
+  module.exports = { __disabled: 'No SSR support' };
+else
+
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||

--- a/src/open.js
+++ b/src/open.js
@@ -1,1 +1,5 @@
+if (typeof window == 'undefined' && typeof module != 'undefined')
+  module.exports = { __disabled: 'No SSR support' };
+else
+
 (function (window, document, Math) {


### PR DESCRIPTION
Fixes #1223, skips running all code in environments without `window` object. This is done to avoid `ReferenceError: window is not defined` error that happens in Node.js when importing `iscroll` module. Scroller functionality is not required during server-side render, but usually will be triggered on the client-side where `window` object is available.

Tested on our project with [vue-iscroll-view](https://github.com/Dafrok/vue-iscroll-view), which is a wrapper Vue component for `iscroll`. SSR works ignoring scroller functionality and client-side works by applying scroller in `mounted` hook (only called on client-side), this is done by [iscroll-view](https://github.com/Dafrok/vue-iscroll-view/blob/efd770fc6e0216976ac8afbdce8a8a7871532bbf/src/index.vue#L116) component.