### PR TITLE
Update _animate.js

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,13 @@
 
 ---
 
+##  Version 5.2.1 - 2018.12.13
+
+### Fixes
+* Fixes weird bug in Safari 12.0.2/OSX 10.13.6. TODO: flesh out this description later.
+
+---
+
 ##  Version 5.2.0 - 2016.04.05
 
 ### Fixes

--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -1,4 +1,4 @@
-/*! iScroll v5.2.0-snapshot ~ (c) 2008-2017 Matteo Spinelli ~ http://cubiq.org/license */
+/*! iScroll v5.2.1-snapshot ~ (c) 2008-2018 Matteo Spinelli ~ http://cubiq.org/license */
 (function (window, document, Math) {
 var rAF = window.requestAnimationFrame	||
 	window.webkitRequestAnimationFrame	||
@@ -411,7 +411,7 @@ function IScroll (el, options) {
 }
 
 IScroll.prototype = {
-	version: '5.2.0-snapshot',
+	version: '5.2.1-snapshot',
 
 	_init: function () {
 		this._initEvents();
@@ -1634,11 +1634,7 @@ IScroll.prototype = {
 			if ( now >= destTime ) {
 				that.isAnimating = false;
 				that._translate(destX, destY);
-
-				if ( !that.resetPosition(that.options.bounceTime) ) {
-					that._execEvent('scrollEnd');
-				}
-
+				that._execEvent('scrollEnd');
 				return;
 			}
 
@@ -1656,6 +1652,7 @@ IScroll.prototype = {
 		this.isAnimating = true;
 		step();
 	},
+
 	handleEvent: function (e) {
 		switch ( e.type ) {
 			case 'touchstart':

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iscroll",
   "description": "Smooth scrolling for the web",
-  "version": "5.2.0-snapshot",
+  "version": "5.2.1-snapshot",
   "homepage": "http://iscrolljs.com",
   "author": "Matteo Spinelli <matteo@cubiq.org> (http://cubiq.org)",
   "keywords": [

--- a/src/default/_animate.js
+++ b/src/default/_animate.js
@@ -14,11 +14,7 @@
 			if ( now >= destTime ) {
 				that.isAnimating = false;
 				that._translate(destX, destY);
-
-				if ( !that.resetPosition(that.options.bounceTime) ) {
-					that._execEvent('scrollEnd');
-				}
-
+				that._execEvent('scrollEnd');
 				return;
 			}
 


### PR DESCRIPTION
I'm seeing a bug in Safari 12.0.2/OSX 10.13.6 in which this condition is not met, and therefore scrollEnd never gets fired. It only happens when the user gets to the end of the scroll pane, goes up a couple pages, then goes back to the end. If I remove the if statement, scrollEnd is always fired and the issue is resolved. Is there a hidden negative to doing that which I've not yet seen?